### PR TITLE
Rollbackversion of angular-editor to one where image upload is working

### DIFF
--- a/src/AdminUI/package.json
+++ b/src/AdminUI/package.json
@@ -11,7 +11,7 @@
     "@angular/platform-browser-dynamic": "^9.1.9",
     "@angular/router": "^9.1.9",
     "@aws-amplify/ui-angular": "^0.2.8",
-    "@kolkov/angular-editor": "^1.1.2",
+    "@kolkov/angular-editor": "1.1.2",
     "@swimlane/ngx-charts": "^14.0.0",
     "aws-amplify": "^3.0.18",
     "aws-amplify-angular": "^5.0.17",


### PR DESCRIPTION
## 🗣 Description

After extensive testing and debugging, an issue was found with the latest angular editor version that was released recently. Rolling back to the version that was initially used and tested on the image upload is working again. Will require a 'npm update' to be run to revert the node module back to the correct version.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
