### PR TITLE
Fix error on svg timeline on subscription stats tab, CPA-494

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/svg-timeline/svg-timeline.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/svg-timeline/svg-timeline.component.ts
@@ -19,7 +19,7 @@ export class SvgTimelineComponent implements OnInit {
 
   @ViewChildren('tick') ticks: ElementRef[];
 
-  items: any[] = [];
+  items: any[] = [{x: 0}];
 
   pixelWidth = 1000;
   lifespanSeconds: number;
@@ -50,12 +50,6 @@ export class SvgTimelineComponent implements OnInit {
         return;
       }
       this.sortEvents();
-
-      this.lifespanSeconds = this.timelineItems[
-        this.timelineItems.length - 1
-      ].date.diff(this.timelineItems[0].date, 'seconds');
-      this.firstDate = this.timelineItems[0].date;
-
       this.drawTimeline();
     }, 300);
   }
@@ -72,11 +66,20 @@ export class SvgTimelineComponent implements OnInit {
     }
   }
 
+  getConfigValues(){
+    this.lifespanSeconds = this.timelineItems[
+      this.timelineItems.length - 1
+    ].date.diff(this.timelineItems[0].date, 'seconds');
+    this.firstDate = this.timelineItems[0].date;
+    
+  }
   /**
    * Builds a collection of items that drive the
    * SVG template creation.
    */
   drawTimeline() {
+    this.getConfigValues()
+    this.items = []
     this.pixelWidth = this.el.nativeElement.offsetWidth;
 
     this.timelineItems.forEach((x) => {


### PR DESCRIPTION
## 🗣 Description

Fix error output on subscription stats page coming from the svg timeline. Added checks to ensure NaN is not being applied to the HTML template

## 💭 Motivation and Context

Bug report CPA-494

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
