### PR TITLE
Monthly Report Single Page Fix

### DIFF
--- a/src/AdminUI/src/app/components/reports/monthly/monthly.component.scss
+++ b/src/AdminUI/src/app/components/reports/monthly/monthly.component.scss
@@ -4,6 +4,9 @@
   size: Letter;
 }
 
+// IMPORTANT : to work with headless chrome and pyppetter report generation
+// the overall height in pixels needs to be 1392px. This comes out to 126.54
+// pixels per inch when converted to letter size (1392 / 11) 
 html {
   background-color: #1b2352;
   display: flex;
@@ -133,7 +136,7 @@ aside {
 #preparedFor {
   color: lightblue;
   flex: 1 1 auto;
-  margin: 200px 0 5px 40px;
+  margin: 190px 0 5px 40px;
   position: relative;
   bottom: 0;
 }


### PR DESCRIPTION
## 🗣 Description

Adjust the sizing of the monthly report to maintain the same look and fit on one page when sent over email or downloaded as pdf. 

## 💭 Motivation and Context

Very simple fix but setting up the local pyppetter/pdf generation to be able to test and get the sizing correct was arduous at best.

## 🧪 Testing

Tested on dev. Checked the send report through email formatting and the download as pdf formatting. Maintained same size on view report functionallity.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
