### PR TITLE
Prevent pdf from being generated before graphs are generated

### DIFF
--- a/src/AdminUI/src/app/components/charts/chart-time-to-first-click-levels/chart-time-to-first-click-levels.component.html
+++ b/src/AdminUI/src/app/components/charts/chart-time-to-first-click-levels/chart-time-to-first-click-levels.component.html
@@ -1,3 +1,4 @@
+<div class="last-cycle-graph"></div>
 <ngx-charts-bar-vertical *ngIf="chart.chartResults"
     [view]=""
     [results]="chart.chartResults"

--- a/src/AdminUI/src/app/components/charts/yearly-clickrate-vs-reportedrate/yearly-clickrate-vs-reportedrate.component.html
+++ b/src/AdminUI/src/app/components/charts/yearly-clickrate-vs-reportedrate/yearly-clickrate-vs-reportedrate.component.html
@@ -1,3 +1,4 @@
+<div class="last-yearly-graph"></div>
 <ngx-charts-line-chart
       [view]=""
       [scheme]="this.chart.colorScheme"


### PR DESCRIPTION
## 🗣 Description

Prevent pdf report from being generated before graphs are rendered. Added invisible div for pyppeteer to refernce within the graph component. Pyppeteer will wait for the element to be present on the page before generating pdf.

## 💭 Motivation and Context

pdf's are being created prior to the ngx charts being populated (data is present on page but the graphs are not rendering)

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
