### PR TITLE
Cpa 622 - Bug - Template editor crashing on tab change 

### DIFF
--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -115,7 +115,8 @@
                 [style.height.px]="text_editor_height"
                 formControlName="templateHTML"
                 [config]="editorConfig"
-              ></angular-editor>{{ angularEditor.focus() }}
+              ></angular-editor>
+              <!-- {{ angularEditor.focus() }} -->
             </div>
           </mat-tab>
 

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -203,9 +203,6 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
         this.angular_editor_mode = "WYSIWYG"
       }
     }
-    console.log(event.currentTarget.outerText)
-    // 
-    console.log("Tab change")
   }
 
   onValueChanges(): void {

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -64,7 +64,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   matchTemplateHTML = new MyErrorStateMatcher();
 
   mailtester_iframe_url = this.cleanURL("");
-
+  currentTab = "HTML View"
 
   //RxJS Subscriptions
   subscriptions = Array<Subscription>();
@@ -173,6 +173,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
 
   }
 
+
   toggleEditorMode(event){
     if($("#justifyLeft-").is(":disabled")){
       this.angular_editor_mode = "WYSIWYG"
@@ -192,6 +193,19 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
     this.configAngularEditor();
     this.addInsertTagButtonIntoEditor();
     $("#toggleEditorMode-").on('mousedown', this.toggleEditorMode.bind(this))
+    $(".mat-tab-label").on('mousedown', this.matTabChange.bind(this))
+  }
+
+  matTabChange(event){
+    if(this.currentTab == "HTML View"){
+      if(this.angular_editor_mode == "Text"){        
+        $("#toggleEditorMode-").click()
+        this.angular_editor_mode = "WYSIWYG"
+      }
+    }
+    console.log(event.currentTarget.outerText)
+    // 
+    console.log("Tab change")
   }
 
   onValueChanges(): void {
@@ -226,7 +240,6 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
         this.templateId = t.template_uuid;
         this.retired = t.retired;
         this.retiredReason = t.retired_description;
-
         this.subscriptionSvc
           .getSubscriptionsByTemplate(t)
           .subscribe((x: PcaSubscription[]) => {
@@ -603,7 +616,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
     uploadUrl: this.image_upload_url,
     //uploadUrl: 'localhost:8080/server/page/upload-image',
     uploadWithCredentials: false,
-    sanitize: true,
+    sanitize: false,
     toolbarPosition: 'top',
     toolbarHiddenButtons: [
       ['bold', 'italic'],


### PR DESCRIPTION
## 🗣 Description

Checks added to detect when tabs are changed. When tabs are changed and the editor is in html mode, it will change the editor back to WYSIWYG mode to prevent crash of the kolkov editor.

## 💭 Motivation and Context

Template Page - Editor crashing if tabs are changed when the editor is html mode.
Fix implemented

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
