### PR TITLE
PCA-890 Multiple Calls for subscription-stats-page on load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .pytest_cache
 .python-version
 __pycache__
+.venv
 
 .vscode
 .idea/

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
@@ -64,7 +64,6 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
         if ('subscription_uuid' in data && !this.subscriptionUuid) {
           this.subscriptionUuid = data.subscription_uuid;
           this.dataAvailable = true;
-          this.drawGraphs();
         }
       })
     );


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
The UI was making multiple calls for subscription-stats on load. Limit this to one call.
Stats are at the cycle level, so only register on change to cycle.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
