### PR TITLE
Set Subscription Time Length 

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -305,10 +305,11 @@
       <mat-label class="h6">Subscription Run Length</mat-label>
       <div class="mb-4">
         <div class="text-muted" *ngIf="sendingProfiles.length > 0">
-          The time that the subscription will take to run. (Must be between 15 minutes and 360 days)
+          The time that the subscription will take to run. (Must be between 15
+          minutes and 360 days)
         </div>
-        <mat-form-field  appearance="outline">
-          <mat-label>Time</mat-label>       
+        <mat-form-field appearance="outline">
+          <mat-label>Time</mat-label>
           <input
             matInput
             formControlName="displayTime"
@@ -330,7 +331,7 @@
           </mat-error>
         </mat-form-field>
         <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
-          <mat-label>Time Units</mat-label>          
+          <mat-label>Time Units</mat-label>
           <mat-select formControlName="timeUnit">
             <mat-option *ngFor="let time of timeRanges" [value]="time">
               {{ time }}</mat-option

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -305,7 +305,7 @@
       <mat-label class="h6">Subscription Run Length</mat-label>
       <div class="mb-4">
         <div class="text-muted" *ngIf="sendingProfiles.length > 0">
-          The time that the subscription will take to run.
+          The time that the subscription will take to run. (Must be between 15 minutes and 360 days)
         </div>
         <mat-form-field  appearance="outline">
           <mat-label>Time</mat-label>       

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -302,6 +302,52 @@
           A Target Email Domain must be specified
         </mat-error>
       </mat-form-field>
+      <mat-label class="h6">Subscription Run Length</mat-label>
+      <div class="mb-4">
+        <div class="text-muted" *ngIf="sendingProfiles.length > 0">
+          The time that the subscription will take to run.
+        </div>
+        <mat-form-field  appearance="outline">
+          <mat-label>Time</mat-label>       
+          <input
+            matInput
+            formControlName="displayTime"
+            type="text"
+            trim="blur"
+            [ngClass]="{ 'is-invalid': submitted }"
+          />
+          <mat-error
+            *ngIf="f.displayTime.errors?.required"
+            class="invalid-feedback"
+          >
+            Run time is a required field
+          </mat-error>
+          <mat-error
+            *ngIf="f.displayTime.errors?.outOfRange"
+            class="invalid-feedback"
+          >
+            Must be between 15 minutes and 360 days
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
+          <mat-label>Time Units</mat-label>          
+          <mat-select formControlName="timeUnit">
+            <mat-option *ngFor="let time of timeRanges" [value]="time">
+              {{ time }}</mat-option
+            >
+          </mat-select>
+          <mat-error
+            *ngIf="submitted && f.sendingProfile.errors?.required"
+            class="invalid-feedback"
+          >
+            Sending Profile required
+          </mat-error>
+        </mat-form-field>
+        <div class="error-color" *ngIf="sendingProfiles.length === 0">
+          A Sending Profile is required, but none are currently configured.
+          Create one or more Sending Profiles before proceeding.
+        </div>
+      </div>
       <div class="text-muted">
         *Note while a subscription is actively running, changes to the email
         list will not take effect until the next 90 day cycle.

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -157,9 +157,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.loadPageForCreate(params);
       } else {
         this.subscriptionSvc.subBehaviorSubject.subscribe((data) => {
-          if ('cycles' in data) {
-            this.loadPageForEdit(data);
-          }
+          this.loadPageForEdit(data);
         });
       }
     });

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -238,7 +238,12 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     )
     this.angular_subs.push(
       this.f.displayTime.valueChanges.subscribe((val) => {
-        this.f.cycle_length_minutes.setValue(this.convertTime(this.previousTimeUnit,"Minutes",this.f.displayTime.value))
+        let valInRange = val;
+        if(this.previousTimeUnit,"Minutes",this.f.displayTime.value < 15){ valInRange = 15}
+        if(this.previousTimeUnit,"Minutes",this.f.displayTime.value > 518400){ valInRange = 518400}
+        console.log(valInRange)
+        this.f.displayTime.setValue(this.convertTime("Minutes",this.previousTimeUnit,valInRange),{emitEvent: false})
+        this.f.cycle_length_minutes.setValue(valInRange)
         this.subscription.cycle_length_minutes = this.f.cycle_length_minutes.value
       })
     )

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -47,12 +47,8 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
   actionEDIT = 'edit';
   actionCREATE = 'create';
   action: string = this.actionEDIT;
-  timeRanges = [
-    'Minutes',
-    'Hours',
-    'Days'
-  ]
-  previousTimeUnit: string = "Minutes"
+  timeRanges = ['Minutes', 'Hours', 'Days'];
+  previousTimeUnit: string = 'Minutes';
 
   // CREATE or EDIT
   pageMode = 'CREATE';
@@ -145,7 +141,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
           ],
           updateOn: 'blur',
         }),
-        cycle_length_minutes: new FormControl(30, {validators: [Validators.required]}),
+        cycle_length_minutes: new FormControl(30, {
+          validators: [Validators.required],
+        }),
         timeUnit: new FormControl('Minutes'),
         displayTime: new FormControl(129600),
         staggerEmails: new FormControl(true, {}),
@@ -232,37 +230,60 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     );
     this.angular_subs.push(
       this.f.timeUnit.valueChanges.subscribe((val) => {
-        this.f.displayTime.setValue(this.convertTime(this.previousTimeUnit,val,this.f.displayTime.value))
+        this.f.displayTime.setValue(
+          this.convertTime(this.previousTimeUnit, val, this.f.displayTime.value)
+        );
         this.previousTimeUnit = val;
       })
-    )
+    );
     this.angular_subs.push(
       this.f.displayTime.valueChanges.subscribe((val) => {
         let valInRange = val;
-        if(this.previousTimeUnit,"Minutes",this.f.displayTime.value < 15){ valInRange = 15}
-        if(this.previousTimeUnit,"Minutes",this.f.displayTime.value > 518400){ valInRange = 518400}
-        console.log(valInRange)
-        this.f.displayTime.setValue(this.convertTime("Minutes",this.previousTimeUnit,valInRange),{emitEvent: false})
-        this.f.cycle_length_minutes.setValue(valInRange)
-        this.subscription.cycle_length_minutes = this.f.cycle_length_minutes.value
+        if ((this.previousTimeUnit, 'Minutes', this.f.displayTime.value < 15)) {
+          valInRange = 15;
+        }
+        if (
+          (this.previousTimeUnit, 'Minutes', this.f.displayTime.value > 518400)
+        ) {
+          valInRange = 518400;
+        }
+        console.log(valInRange);
+        this.f.displayTime.setValue(
+          this.convertTime('Minutes', this.previousTimeUnit, valInRange),
+          { emitEvent: false }
+        );
+        this.f.cycle_length_minutes.setValue(valInRange);
+        this.subscription.cycle_length_minutes = this.f.cycle_length_minutes.value;
       })
-    )
+    );
   }
 
-  convertTime(previousSpan,newSpan,val){
-    if(previousSpan == "Minutes"){
-      if(newSpan == "Hours") {return (val / 60)}
-      if(newSpan == "Days") {return (val / 1440)}
-     }
-     if(previousSpan == "Hours"){
-       if(newSpan == "Minutes") {return (val * 60)}
-       if(newSpan == "Days") {return (val / 24)}
+  convertTime(previousSpan, newSpan, val) {
+    if (previousSpan == 'Minutes') {
+      if (newSpan == 'Hours') {
+        return val / 60;
       }
-      if(previousSpan == "Days"){
-        if(newSpan == "Minutes") {return (val * 1440)}
-        if(newSpan == "Hours") {return (val * 24)}
-       }
-       return val
+      if (newSpan == 'Days') {
+        return val / 1440;
+      }
+    }
+    if (previousSpan == 'Hours') {
+      if (newSpan == 'Minutes') {
+        return val * 60;
+      }
+      if (newSpan == 'Days') {
+        return val / 24;
+      }
+    }
+    if (previousSpan == 'Days') {
+      if (newSpan == 'Minutes') {
+        return val * 1440;
+      }
+      if (newSpan == 'Hours') {
+        return val * 24;
+      }
+    }
+    return val;
   }
 
   /**
@@ -324,7 +345,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     this.customerSvc.getCustomer(s.customer_uuid).subscribe((c: Customer) => {
       this.customer = c;
     });
-    
   }
 
   /**

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
@@ -27,8 +27,8 @@ export class SubscriptionReportTab implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.subscriptionSvc.subBehaviorSubject.subscribe((data: any) => {
-      if ('subscription_uuid' in data) {
+    this.subscriptionSvc.subBehaviorSubject.subscribe((data: Subscription) => {
+      if ('subscription_uuid' in data && data.cycles) {
         this.subscription = data;
         this.emailsSent.sort = this.sort;
         const selectedCycleIndex = 0;

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -59,6 +59,7 @@ export class Subscription {
   stagger_emails: boolean;
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
+  cycle_length_minutes: number;
 }
 
 export class EmailHistory {


### PR DESCRIPTION
## 🗣 Description ##

Added a input box and dropdown to the subscription detail page. Dropdown allows for the setting of time length unit (minutes, hours, days) and the input allows the user to set the value. Restricts the user input to min and max values.

## 💭 Motivation and context ##

Allow the user to set the time length that a subscription will run. Restrict the user to a minimum and maximum value.

## 🧪 Testing ##

Tested locally against development environemnt.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
