### PR TITLE
PCA-913 Restart Subscription Bug

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -582,12 +582,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
       if (result) {
         this.processing = true;
         this.subscription.target_email_list = this.subscription.target_email_list_cached_copy;
-        if (typeof this.f.startDate.value === 'string') {
-          this.f.startDate.setValue(new Date(this.f.startDate.value));
-        }
-        if (this.f.startDate.value.getHours() === 0) {
-          this.f.startDate.value.setHours(10);
-        }
         // persist any changes before restart
         this.subscriptionSvc
           .patchSubscription(this.subscription)


### PR DESCRIPTION
conversions are handled on the backend

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Removed frontend conversions that were messing with timezone and affecting restart subscription start date. All the conversions are handled in the background now and don't need to do them on the frontend.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Subscriptions were not able to restart.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested from UI.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
