### PR TITLE
Remove stagger emails checkbox

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -394,12 +394,6 @@
         list will not take effect until the next 90 day cycle.
       </div>
 
-      <div class="stagger-checkbox">
-        <mat-checkbox formControlName="staggerEmails"
-          >Stagger Email Delivery</mat-checkbox
-        >
-      </div>
-
       <div class="continuous-subscription-checkbox">
         <mat-checkbox formControlName="continuousSubscription"
           >Continuous Subscription Cycles</mat-checkbox

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.scss
@@ -15,10 +15,6 @@
   margin-top: 1em;
 }
 
-.stagger-checkbox {
-  margin: 1rem 0;
-}
-
 .template-selction-container {
   display: flex;
   width: 100%;

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -158,7 +158,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         }),
         timeUnit: new FormControl('Minutes'),
         displayTime: new FormControl(129600),
-        staggerEmails: new FormControl(true, {}),
         continuousSubscription: new FormControl(true, {}),
       },
       { updateOn: 'blur' }
@@ -214,12 +213,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.subscription.target_domain = val;
         this.target_email_domain.next(val);
         this.f.csvText.updateValueAndValidity({ emitEvent: false });
-        this.persistChanges();
-      })
-    );
-    this.angular_subs.push(
-      this.f.staggerEmails.valueChanges.subscribe((val) => {
-        this.subscription.stagger_emails = val;
         this.persistChanges();
       })
     );
@@ -364,7 +357,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
 
     this.f.sendingProfile.setValue(s.sending_profile_name);
     this.f.targetDomain.setValue(s?.target_domain);
-    this.f.staggerEmails.setValue(s.stagger_emails);
     this.f.cycle_length_minutes.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
@@ -740,7 +732,6 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     sub.target_domain = this.target_email_domain.value;
     sub.sending_profile_name = this.f.sendingProfile.value;
 
-    sub.stagger_emails = this.f.staggerEmails.value;
     sub.continuous_subscription = this.f.continuousSubscription.value;
     const cycleLength: number = +this.f.cycle_length_minutes.value;
     sub.cycle_length_minutes = cycleLength;

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -54,7 +54,6 @@ export class Subscription {
   campaigns: GoPhishCampaignModel[];
   sending_profile_name: string;
   target_domain: string;
-  stagger_emails: boolean;
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -141,7 +141,6 @@ export class SubscriptionService {
       target_email_list: subscription.target_email_list,
       sending_profile_name: subscription.sending_profile_name,
       target_domain: subscription.target_domain,
-      stagger_emails: subscription.stagger_emails,
       continuous_subscription: subscription.continuous_subscription,
       templates_selected: subscription.templates_selected,
     };


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Removed stagger delivery checkbox from subscription setup screen.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
The purpose of this was to stagger email delivery so emails sent are built up. However, since the changes made in this [PR](https://github.com/cisagov/con-pca-api/pull/228), this is no longer required as now subscription lengths and counts are validated.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
* Made sure I can restart a current subscription.
* Made sure I can create a new subscription.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
