### PR TITLE
Update refresh token cookie expire date

### DIFF
--- a/src/AdminUI/src/app/services/login.service.ts
+++ b/src/AdminUI/src/app/services/login.service.ts
@@ -62,7 +62,11 @@ export class LoginService {
     localStorage.setItem('expires_at', authResult.expires_at);
     localStorage.setItem('username', authResult.username);
     localStorage.setItem('isAdmin', 'false');
-    this.cookieSvc.set('con-pca-auth-refresh-token', authResult.refresh_token, {secure: true, expires: 30, sameSite: 'Strict'});
+    this.cookieSvc.set('con-pca-auth-refresh-token', authResult.refresh_token, {
+      secure: true,
+      expires: 30,
+      sameSite: 'Strict',
+    });
     this.startRefreshTokenTimer();
     try {
       const jwt = jwt_decode(authResult.id_token);

--- a/src/AdminUI/src/app/services/login.service.ts
+++ b/src/AdminUI/src/app/services/login.service.ts
@@ -62,7 +62,7 @@ export class LoginService {
     localStorage.setItem('expires_at', authResult.expires_at);
     localStorage.setItem('username', authResult.username);
     localStorage.setItem('isAdmin', 'false');
-    this.cookieSvc.set('con-pca-auth-refresh-token', authResult.refresh_token);
+    this.cookieSvc.set('con-pca-auth-refresh-token', authResult.refresh_token, {secure: true, expires: 30, sameSite: 'Strict'});
     this.startRefreshTokenTimer();
     try {
       const jwt = jwt_decode(authResult.id_token);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update the expiration date on the refresh token cookie to match that of the cognito refresh token expiration time period.

## 💭 Motivation and context ##

The refresh token was not persisting through closing the browser and reopening.

## 🧪 Testing ##

Tested locally against a quickly refreshing token. Tested that the cookie persists through browser closing and reopening. 

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
