### PR TITLE
Cycle Report Manual Set Time

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -403,29 +403,30 @@
           Create one or more Sending Profiles before proceeding.
         </div>
       </div>
-      <mat-label class="h6">Reporting Period</mat-label>
+      <mat-label class="h6">Status Report Frequency</mat-label>
       <div class="mb-4">
         <div class="text-muted" *ngIf="sendingProfiles.length > 0">
-          How often a report is sent out to the customer and CISA contact for
-          this subscription. (Must be between 15 minutes and 360 days)
+          The frequency at which the status report is sent out to the customer
+          and CISA contact for this subscription. (Must be between 15 minutes
+          and 360 days)
         </div>
         <mat-form-field appearance="outline">
           <mat-label>Time</mat-label>
           <input
             matInput
-            formControlName="reportingDisplayTime"
+            formControlName="reportDisplayTime"
             type="text"
             trim="blur"
             [ngClass]="{ 'is-invalid': submitted }"
           />
           <mat-error
-            *ngIf="f.reportingDisplayTime.errors?.required"
+            *ngIf="f.reportDisplayTime.errors?.required"
             class="invalid-feedback"
           >
             Run time is a required field
           </mat-error>
           <mat-error
-            *ngIf="f.reportingDisplayTime.errors?.outOfRange"
+            *ngIf="f.reportDisplayTime.errors?.outOfRange"
             class="invalid-feedback"
           >
             Must be between 15 minutes and 360 days
@@ -433,7 +434,7 @@
         </mat-form-field>
         <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
           <mat-label>Time Units</mat-label>
-          <mat-select formControlName="reportingTimeUnit">
+          <mat-select formControlName="reportTimeUnit">
             <mat-option *ngFor="let time of timeRanges" [value]="time">
               {{ time }}</mat-option
             >

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -349,19 +349,19 @@
           <mat-label>Time</mat-label>
           <input
             matInput
-            formControlName="displayTime"
+            formControlName="subDisplayTime"
             type="text"
             trim="blur"
             [ngClass]="{ 'is-invalid': submitted }"
           />
           <mat-error
-            *ngIf="f.displayTime.errors?.required"
+            *ngIf="f.subDisplayTime.errors?.required"
             class="invalid-feedback"
           >
             Run time is a required field
           </mat-error>
           <mat-error
-            *ngIf="f.displayTime.errors?.outOfRange"
+            *ngIf="f.subDisplayTime.errors?.outOfRange"
             class="invalid-feedback"
           >
             Must be between 15 minutes and 360 days
@@ -369,7 +369,7 @@
         </mat-form-field>
         <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
           <mat-label>Time Units</mat-label>
-          <mat-select formControlName="timeUnit">
+          <mat-select formControlName="subTimeUnit">
             <mat-option *ngFor="let time of timeRanges" [value]="time">
               {{ time }}</mat-option
             >
@@ -380,6 +380,56 @@
           >
             Sending Profile required
           </mat-error>
+        </mat-form-field>
+        <div class="error-color" *ngIf="!isValidConfig">
+          {{ validConfigMessage }}
+        </div>
+        <div class="error-color" *ngIf="sendingProfiles.length === 0">
+          A Sending Profile is required, but none are currently configured.
+          Create one or more Sending Profiles before proceeding.
+        </div>
+      </div>
+      <mat-label class="h6">Reporting Period</mat-label>
+      <div class="mb-4">
+        <div class="text-muted" *ngIf="sendingProfiles.length > 0">
+          How often a report is sent out to the customer and CISA contact for this subscription.
+          (Must be between 15 minutes and 360 days)
+        </div>
+        <mat-form-field appearance="outline">
+          <mat-label>Time</mat-label>
+          <input
+            matInput
+            formControlName="reportingDisplayTime"
+            type="text"
+            trim="blur"
+            [ngClass]="{ 'is-invalid': submitted }"
+          />
+          <mat-error
+            *ngIf="f.reportingDisplayTime.errors?.required"
+            class="invalid-feedback"
+          >
+            Run time is a required field
+          </mat-error>
+          <mat-error
+            *ngIf="f.reportingDisplayTime.errors?.outOfRange"
+            class="invalid-feedback"
+          >
+            Must be between 15 minutes and 360 days
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
+          <mat-label>Time Units</mat-label>
+          <mat-select formControlName="reportingTimeUnit">
+            <mat-option *ngFor="let time of timeRanges" [value]="time">
+              {{ time }}</mat-option
+            >
+          </mat-select>
+          <!-- <mat-error
+            *ngIf="submitted && f.sendingProfile.errors?.required"
+            class="invalid-feedback"
+          >
+            Sending Profile required
+          </mat-error> -->
         </mat-form-field>
         <div class="error-color" *ngIf="!isValidConfig">
           {{ validConfigMessage }}

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -406,8 +406,8 @@
       <mat-label class="h6">Reporting Period</mat-label>
       <div class="mb-4">
         <div class="text-muted" *ngIf="sendingProfiles.length > 0">
-          How often a report is sent out to the customer and CISA contact for this subscription.
-          (Must be between 15 minutes and 360 days)
+          How often a report is sent out to the customer and CISA contact for
+          this subscription. (Must be between 15 minutes and 360 days)
         </div>
         <mat-form-field appearance="outline">
           <mat-label>Time</mat-label>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -254,7 +254,11 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
           convertedVal = 518400;
         }
         this.f.subDisplayTime.setValue(
-          this.convertTime('Minutes', this.subscriptionPreviousTimeUnit, convertedVal),
+          this.convertTime(
+            'Minutes',
+            this.subscriptionPreviousTimeUnit,
+            convertedVal
+          ),
           { emitEvent: false }
         );
         this.f.cycle_length_minutes.setValue(convertedVal);
@@ -263,7 +267,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.checkValid();
       })
     );
-    
+
     this.angular_subs.push(
       this.f.reportingTimeUnit.valueChanges.subscribe((val) => {
         this.f.reportingDisplayTime.setValue(
@@ -290,7 +294,11 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
           convertedVal = 518400;
         }
         this.f.reportingDisplayTime.setValue(
-          this.convertTime('Minutes', this.reportingPeriodPreviousTimeUnit, convertedVal),
+          this.convertTime(
+            'Minutes',
+            this.reportingPeriodPreviousTimeUnit,
+            convertedVal
+          ),
           { emitEvent: false }
         );
         this.f.reporting_length_minutes.setValue(convertedVal);
@@ -402,11 +410,15 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     this.f.cycle_length_minutes.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
-    let reportingLengthMinutes = s.reporting_length_minutes ? s.reporting_length_minutes : 129600 
+    let reportingLengthMinutes = s.reporting_length_minutes
+      ? s.reporting_length_minutes
+      : 129600;
     this.f.reporting_length_minutes.setValue(reportingLengthMinutes, {
       emitEvent: false,
     });
-    this.f.subDisplayTime.setValue(s.cycle_length_minutes, { emitEvent: false });
+    this.f.subDisplayTime.setValue(s.cycle_length_minutes, {
+      emitEvent: false,
+    });
     this.f.continuousSubscription.setValue(s.continuous_subscription);
     this.enableDisableFields();
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -54,7 +54,8 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
   actionCREATE = 'create';
   action: string = this.actionEDIT;
   timeRanges = ['Minutes', 'Hours', 'Days'];
-  previousTimeUnit: string = 'Minutes';
+  subscriptionPreviousTimeUnit: string = 'Minutes';
+  reportingPeriodPreviousTimeUnit: string = 'Minutes';
   templatesSelected = new TemplateSelected();
   templatesAvailable = new TemplateSelected();
 
@@ -156,8 +157,13 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         cycle_length_minutes: new FormControl(129600, {
           validators: [Validators.required],
         }),
-        timeUnit: new FormControl('Minutes'),
-        displayTime: new FormControl(129600),
+        subTimeUnit: new FormControl('Minutes'),
+        subDisplayTime: new FormControl(129600),
+        reporting_length_minutes: new FormControl(129600, {
+          validators: [Validators.required],
+        }),
+        reportingTimeUnit: new FormControl('Minutes'),
+        reportingDisplayTime: new FormControl(129600),
         continuousSubscription: new FormControl(true, {}),
       },
       { updateOn: 'blur' }
@@ -223,37 +229,73 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
       })
     );
     this.angular_subs.push(
-      this.f.timeUnit.valueChanges.subscribe((val) => {
-        this.f.displayTime.setValue(
+      this.f.subTimeUnit.valueChanges.subscribe((val) => {
+        this.f.subDisplayTime.setValue(
           this.convertTime(
-            this.previousTimeUnit,
+            this.subscriptionPreviousTimeUnit,
             val,
-            this.f.displayTime.value
+            this.f.subDisplayTime.value
           ),
           { emitEvent: false }
         );
-        this.previousTimeUnit = val;
+        this.subscriptionPreviousTimeUnit = val;
       })
     );
     this.angular_subs.push(
-      this.f.displayTime.valueChanges.subscribe((val) => {
+      this.f.subDisplayTime.valueChanges.subscribe((val) => {
         let convertedVal = this.convertTime(
-          this.previousTimeUnit,
+          this.subscriptionPreviousTimeUnit,
           'Minutes',
-          this.f.displayTime.value
+          this.f.subDisplayTime.value
         );
         if (convertedVal < 15) {
           convertedVal = 15;
         } else if (convertedVal > 518400) {
           convertedVal = 518400;
         }
-        this.f.displayTime.setValue(
-          this.convertTime('Minutes', this.previousTimeUnit, convertedVal),
+        this.f.subDisplayTime.setValue(
+          this.convertTime('Minutes', this.subscriptionPreviousTimeUnit, convertedVal),
           { emitEvent: false }
         );
         this.f.cycle_length_minutes.setValue(convertedVal);
         this.subscription.cycle_length_minutes =
           this.f.cycle_length_minutes.value;
+        this.checkValid();
+      })
+    );
+    
+    this.angular_subs.push(
+      this.f.reportingTimeUnit.valueChanges.subscribe((val) => {
+        this.f.reportingDisplayTime.setValue(
+          this.convertTime(
+            this.reportingPeriodPreviousTimeUnit,
+            val,
+            this.f.reportingDisplayTime.value
+          ),
+          { emitEvent: false }
+        );
+        this.reportingPeriodPreviousTimeUnit = val;
+      })
+    );
+    this.angular_subs.push(
+      this.f.reportingDisplayTime.valueChanges.subscribe((val) => {
+        let convertedVal = this.convertTime(
+          this.reportingPeriodPreviousTimeUnit,
+          'Minutes',
+          this.f.reportingDisplayTime.value
+        );
+        if (convertedVal < 15) {
+          convertedVal = 15;
+        } else if (convertedVal > 518400) {
+          convertedVal = 518400;
+        }
+        this.f.reportingDisplayTime.setValue(
+          this.convertTime('Minutes', this.reportingPeriodPreviousTimeUnit, convertedVal),
+          { emitEvent: false }
+        );
+        this.f.reporting_length_minutes.setValue(convertedVal);
+        this.subscription.reporting_length_minutes =
+          this.f.reporting_length_minutes.value;
         this.checkValid();
       })
     );
@@ -360,7 +402,11 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     this.f.cycle_length_minutes.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
-    this.f.displayTime.setValue(s.cycle_length_minutes, { emitEvent: false });
+    let reportingLengthMinutes = s.reporting_length_minutes ? s.reporting_length_minutes : 129600 
+    this.f.reporting_length_minutes.setValue(reportingLengthMinutes, {
+      emitEvent: false,
+    });
+    this.f.subDisplayTime.setValue(s.cycle_length_minutes, { emitEvent: false });
     this.f.continuousSubscription.setValue(s.continuous_subscription);
     this.enableDisableFields();
 
@@ -734,7 +780,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
 
     sub.continuous_subscription = this.f.continuousSubscription.value;
     const cycleLength: number = +this.f.cycle_length_minutes.value;
+    const reportingLength: number = +this.f.reporting_length_minutes.value;
     sub.cycle_length_minutes = cycleLength;
+    sub.reporting_length_minutes = reportingLength;
     this.setTemplatesSelected();
     sub.templates_selected = this.subscription.templates_selected;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -159,7 +159,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         }),
         subTimeUnit: new FormControl('Minutes'),
         subDisplayTime: new FormControl(129600),
-        report_length_minutes: new FormControl(43200, {
+        report_frequency_minutes: new FormControl(43200, {
           validators: [Validators.required],
         }),
         reportTimeUnit: new FormControl('Minutes'),
@@ -302,9 +302,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
           ),
           { emitEvent: false }
         );
-        this.f.report_length_minutes.setValue(convertedVal);
-        this.subscription.report_length_minutes =
-          this.f.report_length_minutes.value;
+        this.f.report_frequency_minutes.setValue(convertedVal);
+        this.subscription.report_frequency_minutes =
+          this.f.report_frequency_minutes.value;
         this.checkValid();
         this.persistChanges();
       })
@@ -412,13 +412,13 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     this.f.cycle_length_minutes.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
-    this.f.report_length_minutes.setValue(s.report_length_minutes, {
+    this.f.report_frequency_minutes.setValue(s.report_frequency_minutes, {
       emitEvent: false,
     });
     this.f.subDisplayTime.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
-    this.f.reportDisplayTime.setValue(s.report_length_minutes, {
+    this.f.reportDisplayTime.setValue(s.report_frequency_minutes, {
       emitEvent: false,
     });
     this.f.continuousSubscription.setValue(s.continuous_subscription);
@@ -794,9 +794,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
 
     sub.continuous_subscription = this.f.continuousSubscription.value;
     const cycleLength: number = +this.f.cycle_length_minutes.value;
-    const reportLength: number = +this.f.report_length_minutes.value;
+    const reportLength: number = +this.f.report_frequency_minutes.value;
     sub.cycle_length_minutes = cycleLength;
-    sub.report_length_minutes = reportLength;
+    sub.report_frequency_minutes = reportLength;
     this.setTemplatesSelected();
     sub.templates_selected = this.subscription.templates_selected;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -265,6 +265,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.subscription.cycle_length_minutes =
           this.f.cycle_length_minutes.value;
         this.checkValid();
+        this.persistChanges();
       })
     );
 
@@ -305,6 +306,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.subscription.report_length_minutes =
           this.f.report_length_minutes.value;
         this.checkValid();
+        this.persistChanges();
       })
     );
   }
@@ -414,6 +416,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
       emitEvent: false,
     });
     this.f.subDisplayTime.setValue(s.cycle_length_minutes, {
+      emitEvent: false,
+    });
+    this.f.reportDisplayTime.setValue(s.report_length_minutes, {
       emitEvent: false,
     });
     this.f.continuousSubscription.setValue(s.continuous_subscription);

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -54,8 +54,8 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
   actionCREATE = 'create';
   action: string = this.actionEDIT;
   timeRanges = ['Minutes', 'Hours', 'Days'];
-  subscriptionPreviousTimeUnit: string = 'Minutes';
-  reportingPeriodPreviousTimeUnit: string = 'Minutes';
+  subscriptionPreviousTimeUnit = 'Minutes';
+  reportPeriodPreviousTimeUnit = 'Minutes';
   templatesSelected = new TemplateSelected();
   templatesAvailable = new TemplateSelected();
 
@@ -159,11 +159,11 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         }),
         subTimeUnit: new FormControl('Minutes'),
         subDisplayTime: new FormControl(129600),
-        reporting_length_minutes: new FormControl(43200, {
+        report_length_minutes: new FormControl(43200, {
           validators: [Validators.required],
         }),
-        reportingTimeUnit: new FormControl('Minutes'),
-        reportingDisplayTime: new FormControl(43200),
+        reportTimeUnit: new FormControl('Minutes'),
+        reportDisplayTime: new FormControl(43200),
         continuousSubscription: new FormControl(true, {}),
       },
       { updateOn: 'blur' }
@@ -269,41 +269,41 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     );
 
     this.angular_subs.push(
-      this.f.reportingTimeUnit.valueChanges.subscribe((val) => {
-        this.f.reportingDisplayTime.setValue(
+      this.f.reportTimeUnit.valueChanges.subscribe((val) => {
+        this.f.reportDisplayTime.setValue(
           this.convertTime(
-            this.reportingPeriodPreviousTimeUnit,
+            this.reportPeriodPreviousTimeUnit,
             val,
-            this.f.reportingDisplayTime.value
+            this.f.reportDisplayTime.value
           ),
           { emitEvent: false }
         );
-        this.reportingPeriodPreviousTimeUnit = val;
+        this.reportPeriodPreviousTimeUnit = val;
       })
     );
     this.angular_subs.push(
-      this.f.reportingDisplayTime.valueChanges.subscribe((val) => {
+      this.f.reportDisplayTime.valueChanges.subscribe((val) => {
         let convertedVal = this.convertTime(
-          this.reportingPeriodPreviousTimeUnit,
+          this.reportPeriodPreviousTimeUnit,
           'Minutes',
-          this.f.reportingDisplayTime.value
+          this.f.reportDisplayTime.value
         );
         if (convertedVal < 15) {
           convertedVal = 15;
         } else if (convertedVal > 518400) {
           convertedVal = 518400;
         }
-        this.f.reportingDisplayTime.setValue(
+        this.f.reportDisplayTime.setValue(
           this.convertTime(
             'Minutes',
-            this.reportingPeriodPreviousTimeUnit,
+            this.reportPeriodPreviousTimeUnit,
             convertedVal
           ),
           { emitEvent: false }
         );
-        this.f.reporting_length_minutes.setValue(convertedVal);
-        this.subscription.reporting_length_minutes =
-          this.f.reporting_length_minutes.value;
+        this.f.report_length_minutes.setValue(convertedVal);
+        this.subscription.report_length_minutes =
+          this.f.report_length_minutes.value;
         this.checkValid();
       })
     );
@@ -410,10 +410,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
     this.f.cycle_length_minutes.setValue(s.cycle_length_minutes, {
       emitEvent: false,
     });
-    let reportingLengthMinutes = s.reporting_length_minutes
-      ? s.reporting_length_minutes
-      : 129600;
-    this.f.reporting_length_minutes.setValue(reportingLengthMinutes, {
+    this.f.report_length_minutes.setValue(s.report_length_minutes, {
       emitEvent: false,
     });
     this.f.subDisplayTime.setValue(s.cycle_length_minutes, {
@@ -792,9 +789,9 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
 
     sub.continuous_subscription = this.f.continuousSubscription.value;
     const cycleLength: number = +this.f.cycle_length_minutes.value;
-    const reportingLength: number = +this.f.reporting_length_minutes.value;
+    const reportLength: number = +this.f.report_length_minutes.value;
     sub.cycle_length_minutes = cycleLength;
-    sub.reporting_length_minutes = reportingLength;
+    sub.report_length_minutes = reportLength;
     this.setTemplatesSelected();
     sub.templates_selected = this.subscription.templates_selected;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -159,11 +159,11 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         }),
         subTimeUnit: new FormControl('Minutes'),
         subDisplayTime: new FormControl(129600),
-        reporting_length_minutes: new FormControl(129600, {
+        reporting_length_minutes: new FormControl(43200, {
           validators: [Validators.required],
         }),
         reportingTimeUnit: new FormControl('Minutes'),
-        reportingDisplayTime: new FormControl(129600),
+        reportingDisplayTime: new FormControl(43200),
         continuousSubscription: new FormControl(true, {}),
       },
       { updateOn: 'blur' }

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -57,6 +57,7 @@ export class Subscription {
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;
+  reporting_length_minutes:number;
   templates_selected: TemplateSelected;
 }
 

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -57,7 +57,7 @@ export class Subscription {
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;
-  reporting_length_minutes: number;
+  report_length_minutes: number;
   templates_selected: TemplateSelected;
 }
 

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -57,7 +57,7 @@ export class Subscription {
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;
-  report_length_minutes: number;
+  report_frequency_minutes: number;
   templates_selected: TemplateSelected;
 }
 

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -57,7 +57,7 @@ export class Subscription {
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;
-  reporting_length_minutes:number;
+  reporting_length_minutes: number;
   templates_selected: TemplateSelected;
 }
 

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -144,7 +144,7 @@ export class SubscriptionService {
       continuous_subscription: subscription.continuous_subscription,
       templates_selected: subscription.templates_selected,
       cycle_length_minutes: subscription.cycle_length_minutes,
-      report_length_minutes: subscription.report_length_minutes,
+      report_frequency_minutes: subscription.report_frequency_minutes,
     };
 
     return this.http.patch(

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -143,6 +143,8 @@ export class SubscriptionService {
       target_domain: subscription.target_domain,
       continuous_subscription: subscription.continuous_subscription,
       templates_selected: subscription.templates_selected,
+      cycle_length_minutes: subscription.cycle_length_minutes,
+      report_length_minutes: subscription.report_length_minutes,
     };
 
     return this.http.patch(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Allow for a minute value to be set to a subscription to determine the time between reports being sent out. Allows the user to set the time in minutes, hours, or days. Reloads previous value if one has been set.

## 💭 Motivation and context ##

Allow the user to specify the time between reports on a subscription.

## 🧪 Testing ##

Tested locally using the make tasks script to simulate the sqs tasks being queued and run.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.