### PR TITLE
CPD-180 Allow ignoring config warmup recommendations

### DIFF
--- a/src/AdminUI/src/app/components/customers/customers.component.ts
+++ b/src/AdminUI/src/app/components/customers/customers.component.ts
@@ -71,7 +71,9 @@ export class CustomersComponent implements OnInit {
    *
    */
   private refresh(): void {
-    this.layout_service.setTitle('Customers');
+    if (!this.insideDialog) {
+      this.layout_service.setTitle('Customers');
+    }
     this.loading = true;
     this.customerSvc.getCustomers().subscribe((data: any) => {
       this.customersData.data = data as Customer[];

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -382,8 +382,15 @@
             >
           </mat-select>
         </mat-form-field>
-        <div class="error-color" *ngIf="!isValidConfig">
+        <div class="error-color mb-3" *ngIf="!isValidConfig">
           {{ validConfigMessage }}
+        </div>
+        <div class="error-color" *ngIf="!isValidConfig">
+          <mat-checkbox (change)="setIgnoreConfigError($event)">
+            I understand that this configuration does not fall within
+            recommended email sending guidelines, but would like to continue
+            anyway.
+          </mat-checkbox>
         </div>
       </div>
       <mat-label class="h6">Status Report Frequency</mat-label>
@@ -434,7 +441,7 @@
           type="submit"
           mat-raised-button
           color="primary"
-          [disabled]="launchSubmitted || !isValidConfig"
+          [disabled]="launchSubmitted || (!isValidConfig && !ignoreConfigError)"
           (click)="onSubmit()"
           *ngIf="pageMode == 'CREATE'"
         >
@@ -481,7 +488,7 @@
                 subscription?.status == 'created') &&
               !subscription?.archived
             "
-            [disabled]="processing || !isValidConfig"
+            [disabled]="processing || (!isValidConfig && !ignoreConfigError)"
             color="primary"
             (click)="startSubscription()"
           >

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -33,8 +33,8 @@ import { TemplateManagerService } from 'src/app/services/template-manager.servic
 import { SettingsService } from 'src/app/services/settings.service';
 import { BehaviorSubject } from 'rxjs';
 import { filterSendingProfiles } from '../../../../helper/utilities';
-import { Template } from 'src/app/models/template.model';
 import { TemplateSelectDialogComponent } from 'src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component';
+import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
   selector: 'subscription-config-tab',
@@ -61,6 +61,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
 
   // Valid configuration
   isValidConfig = true;
+  ignoreConfigError = false;
   validConfigMessage = '';
 
   // CREATE or EDIT
@@ -164,7 +165,7 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         }),
         reportTimeUnit: new FormControl('Minutes'),
         reportDisplayTime: new FormControl(43200),
-        continuousSubscription: new FormControl(true, {}),
+        continuousSubscription: new FormControl(false, {}),
       },
       { updateOn: 'blur' }
     );
@@ -1055,6 +1056,10 @@ export class SubscriptionConfigTab implements OnInit, OnDestroy {
         this.validConfigMessage = error.error;
       }
     );
+  }
+
+  setIgnoreConfigError(event: MatCheckboxChange) {
+    this.ignoreConfigError = event.checked;
   }
 
   changeTemplate(input) {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Add a checkbox to allow ignoring errors when target count and length do not sit within the recommended warm-up rates.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Sometimes warmups are done manually over multiple cycles. By ignoring errors, it allows us to do these warmups manually. 
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
