### PR TITLE
Download subscription data on reporting tab

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.html
@@ -114,7 +114,7 @@
   </mat-card>
   <mat-card>
     <mat-label class="h6">Download Subscription Data</mat-label>
-    <div >
+    <div>
       <div
         *ngIf="loading"
         style="text-align: center; padding-top: 2rem; padding-bottom: 2rem"
@@ -125,7 +125,9 @@
           diameter="50"
         ></mat-spinner>
       </div>
-      <div class="text-muted">Download all data associated with this subscription</div>
+      <div class="text-muted">
+        Download all data associated with this subscription
+      </div>
       <button
         mat-raised-button
         color="primary"
@@ -136,7 +138,7 @@
       </button>
     </div>
   </mat-card>
-  
+
   <!--
     <div *ngIf="subscription">
         <mat-form-field class="cycle-select-dropdown" *ngIf="subscription.cycles" appearance="outline">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.html
@@ -1,5 +1,4 @@
 <div *ngIf="subscription['cycles']">
-  testsetset
   <mat-card *ngIf="subscription['cycles']">
     <mat-card-title> Reporting </mat-card-title>
     Reporting Cycle:
@@ -113,6 +112,31 @@
       ><br />
     </div>
   </mat-card>
+  <mat-card>
+    <mat-label class="h6">Download Subscription Data</mat-label>
+    <div >
+      <div
+        *ngIf="loading"
+        style="text-align: center; padding-top: 2rem; padding-bottom: 2rem"
+      >
+        <mat-spinner
+          class="spinner"
+          style="margin-left: auto; margin-right: auto"
+          diameter="50"
+        ></mat-spinner>
+      </div>
+      <div class="text-muted">Download all data associated with this subscription</div>
+      <button
+        mat-raised-button
+        color="primary"
+        class="mb-3"
+        (click)="downloadSubscriptionData(); $event.preventDefault()"
+      >
+        Download Data
+      </button>
+    </div>
+  </mat-card>
+  
   <!--
     <div *ngIf="subscription">
         <mat-form-field class="cycle-select-dropdown" *ngIf="subscription.cycles" appearance="outline">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
@@ -215,12 +215,10 @@ export class SubscriptionReportTab implements OnInit {
       );
   }
   downloadSubscriptionData() {
-    console.log(this.subscription);
     this.subscriptionSvc
       .getSubscriptionJSON(this.subscription.subscription_uuid)
       .subscribe(
         (blob) => {
-          console.log(blob);
           this.downloadObject(
             `${this.subscription.name}_subscription_data.json`,
             blob

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
@@ -214,4 +214,22 @@ export class SubscriptionReportTab implements OnInit {
         }
       );
   }
+  downloadSubscriptionData() {
+    this.subscriptionSvc
+      .getSubscriptionJSON(this.subscription.subscription_uuid)      
+      .subscribe(
+        (blob) => {
+          console.log(blob)
+          this.downloadObject('subscription.json', blob);
+        },
+        (error) => {
+          this.dialog.open(AlertComponent, {
+            data: {
+              title: 'Error',
+              messageText: `An error occured downloading the subscription JSON data. Check logs for more detail.`,
+            },
+          });
+        }
+      );
+  }
 }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-report-tab/subscription-report-tab.component.ts
@@ -215,12 +215,16 @@ export class SubscriptionReportTab implements OnInit {
       );
   }
   downloadSubscriptionData() {
+    console.log(this.subscription);
     this.subscriptionSvc
-      .getSubscriptionJSON(this.subscription.subscription_uuid)      
+      .getSubscriptionJSON(this.subscription.subscription_uuid)
       .subscribe(
         (blob) => {
-          console.log(blob)
-          this.downloadObject('subscription.json', blob);
+          console.log(blob);
+          this.downloadObject(
+            `${this.subscription.name}_subscription_data.json`,
+            blob
+          );
         },
         (error) => {
           this.dialog.open(AlertComponent, {

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.html
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.html
@@ -14,10 +14,19 @@
 
     <!-- CREATE TEMPLATE -->
     <div class="d-inline-flex flex-column ml-2">
-      <button mat-raised-button color="primary" routerLink="/templatemanager">
-        New Template
-      </button>
-
+      <div class="d-flex">
+        <button mat-raised-button color="primary" routerLink="/templatemanager">
+          New Template
+        </button>
+        <button
+          style="width: 1em"
+          mat-raised-button
+          color="primary"
+          (click)="downloadTemplatesJSON()"
+        >
+          <mat-icon>download</mat-icon>
+        </button>
+      </div>
       <mat-slide-toggle
         class="mt-3 ml-1 mb-2"
         [(ngModel)]="showRetired"

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.scss
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.scss
@@ -38,3 +38,7 @@ mat-form-field.mat-form-field {
   -webkit-hyphens: auto;
   hyphens: auto;
 }
+.mat-column-select {
+  flex: 0 0 8%;
+  min-width: 75px;
+}

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
@@ -83,7 +83,6 @@ export class TemplatesPageComponent implements OnInit, AfterViewInit {
     if (confirm('Download all templates?')) {
       this.templateSvc.getTemplatesJSON(this.showRetired).subscribe(
         (blob) => {
-          console.log(blob);
           this.downloadObject(`template_data.json`, blob);
         },
         (error) => {

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
@@ -5,6 +5,8 @@ import { TemplateManagerService } from 'src/app/services/template-manager.servic
 import { Template } from 'src/app/models/template.model';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatSort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { AlertComponent } from 'src/app/components/dialogs/alert/alert.component';
 
 @Component({
   selector: '',
@@ -30,7 +32,8 @@ export class TemplatesPageComponent implements OnInit, AfterViewInit {
   constructor(
     private templateSvc: TemplateManagerService,
     private router: Router,
-    private layoutSvc: LayoutMainService
+    private layoutSvc: LayoutMainService,
+    public dialog: MatDialog
   ) {
     layoutSvc.setTitle('Templates');
   }
@@ -66,5 +69,32 @@ export class TemplatesPageComponent implements OnInit, AfterViewInit {
       this.displayedColumns.push('retired');
     }
     this.refresh();
+  }
+  downloadObject(filename, blob) {
+    const a = document.createElement('a');
+    const objectUrl = URL.createObjectURL(blob);
+    a.href = objectUrl;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(objectUrl);
+  }
+
+  downloadTemplatesJSON() {
+    if (confirm('Download all templates?')) {
+      this.templateSvc.getTemplatesJSON(this.showRetired).subscribe(
+        (blob) => {
+          console.log(blob);
+          this.downloadObject(`template_data.json`, blob);
+        },
+        (error) => {
+          this.dialog.open(AlertComponent, {
+            data: {
+              title: 'Error',
+              messageText: `An error occured downloading the template data. Check logs for more detail.`,
+            },
+          });
+        }
+      );
+    }
   }
 }

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -312,4 +312,10 @@ export class SubscriptionService {
     const url = `${this.settingsService.settings.apiUrl}/api/v1/templates/select/`;
     return this.http.get<TemplateSelected>(url).toPromise();
   }
+
+  public getSubscriptionJSON(subscription_uuid) {
+    const headers = new HttpHeaders().set('content-type', 'application/json');
+    const url = `${this.settingsService.settings.apiUrl}/api/v1/subscription/downloadjson/${subscription_uuid}/`;
+    return this.http.get(url, { headers, responseType: 'blob' });
+  }
 }

--- a/src/AdminUI/src/app/services/template-manager.service.ts
+++ b/src/AdminUI/src/app/services/template-manager.service.ts
@@ -135,4 +135,14 @@ export class TemplateManagerService {
     };
     return this.http.post(url, data);
   }
+
+  public getTemplatesJSON(showRetired) {
+    const headers = new HttpHeaders().set('content-type', 'application/json');
+    const parameters = [];
+    parameters.push(`retired=${showRetired}`);
+    const url = `${
+      this.settingsService.settings.apiUrl
+    }/api/v1/templates/downloadjson/?${parameters.join('&')}`;
+    return this.http.get(url, { headers, responseType: 'blob' });
+  }
 }


### PR DESCRIPTION
## 🗣 Description ##

Add a button the subscription reporting tab. Button allows for download of subscription data as a json. Add service endpoint to access the API.

## 💭 Motivation and context ##

Allow for access to the 'download subscription JSON' api endpoint from the UI. Download the data as a straight json file format.

## 🧪 Testing ##

Tested locally against multiple subscriptions.

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
