### PR TITLE
Cpd 182

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -619,6 +619,7 @@ export class SubscriptionConfigTab
   subValid() {
     // stop here if form is invalid
     if (this.subscribeForm.invalid) {
+      console.log(this.subscribeForm)
       return false;
     }
 
@@ -736,9 +737,12 @@ export class SubscriptionConfigTab
    * Submits the form to create or save a Subscription.
    */
   save() {
+    console.log("test")
     if (!this.subValid()) {
+      console.log("test1")
       return;
     }
+    console.log("test2")
 
     const sub = this.subscriptionSvc.subscription;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -619,7 +619,7 @@ export class SubscriptionConfigTab
   subValid() {
     // stop here if form is invalid
     if (this.subscribeForm.invalid) {
-      console.log(this.subscribeForm)
+      console.log(this.subscribeForm);
       return false;
     }
 
@@ -737,12 +737,12 @@ export class SubscriptionConfigTab
    * Submits the form to create or save a Subscription.
    */
   save() {
-    console.log("test")
+    console.log('test');
     if (!this.subValid()) {
-      console.log("test1")
+      console.log('test1');
       return;
     }
-    console.log("test2")
+    console.log('test2');
 
     const sub = this.subscriptionSvc.subscription;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -619,7 +619,6 @@ export class SubscriptionConfigTab
   subValid() {
     // stop here if form is invalid
     if (this.subscribeForm.invalid) {
-      console.log(this.subscribeForm);
       return false;
     }
 
@@ -737,12 +736,9 @@ export class SubscriptionConfigTab
    * Submits the form to create or save a Subscription.
    */
   save() {
-    console.log('test');
     if (!this.subValid()) {
-      console.log('test1');
       return;
     }
-    console.log('test2');
 
     const sub = this.subscriptionSvc.subscription;
 

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -436,9 +436,7 @@
         >
           New Template
         </button> -->
-        <!-- <button id="delete-button" class="d-flex" mat-raised-button color="warn" (click)="deleteTemplate()" *ngIf=templateId>
-          Delete Template
-        </button> -->
+
         <div class="flex-container flex-row save_container pb-3">
           <button
             id="retire-button"
@@ -470,16 +468,21 @@
           >
             Stop Template
           </button>
-          <button
-            id="stop-button"
-            class="d-flex"
-            mat-raised-button
-            color="warn"
-            (click)="deleteTemplate()"
-            *ngIf="canDelete && templateId"
+          <div
+          [matTooltip]="deleteTooltip"
           >
-            Delete Template
-          </button>
+            <button
+              id="stop-button"
+              class="d-flex"
+              mat-raised-button
+              [disabled]="!canDelete"
+              color="warn"
+              (click)="deleteTemplate()"
+              *ngIf="retired && templateId"
+            >
+              Delete Template
+            </button>
+          </div>
           <div class="ml-auto d-flex flex-row">
             <button
               id="save-button"

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -468,9 +468,7 @@
           >
             Stop Template
           </button>
-          <div
-          [matTooltip]="deleteTooltip"
-          >
+          <div [matTooltip]="deleteTooltip">
             <button
               id="stop-button"
               class="d-flex"

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -66,7 +66,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   templateId: string;
   retired: boolean;
   canDelete: boolean = false;
-  deleteTooltip: string = ""
+  deleteTooltip: string = '';
   canStop: boolean = false;
   retiredReason: string;
   currentTemplateFormGroup: FormGroup;
@@ -522,7 +522,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
       if (result.retired) {
         this.retired = result.retired;
         this.retiredReason = result.description;
-        this.setCanDelete()
+        this.setCanDelete();
       }
     });
   }
@@ -820,10 +820,11 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   setCanDelete() {
     if (this.pcaSubscriptions.data.length > 0) {
       this.canDelete = false;
-      this.deleteTooltip = "Can not delete templates associated with a subscription"
+      this.deleteTooltip =
+        'Can not delete templates associated with a subscription';
     } else {
       this.canDelete = true;
-      this.deleteTooltip = "Delete the template"
+      this.deleteTooltip = 'Delete the template';
     }
   }
 

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -66,6 +66,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   templateId: string;
   retired: boolean;
   canDelete: boolean = false;
+  deleteTooltip: string = ""
   canStop: boolean = false;
   retiredReason: string;
   currentTemplateFormGroup: FormGroup;
@@ -521,6 +522,7 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
       if (result.retired) {
         this.retired = result.retired;
         this.retiredReason = result.description;
+        this.setCanDelete()
       }
     });
   }
@@ -818,8 +820,10 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   setCanDelete() {
     if (this.pcaSubscriptions.data.length > 0) {
       this.canDelete = false;
+      this.deleteTooltip = "Can not delete templates associated with a subscription"
     } else {
       this.canDelete = true;
+      this.deleteTooltip = "Delete the template"
     }
   }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Rework existing delete template components and update for current state of the application. Allows for deletion of templates through the ui if the template is in a state that that allows for deletion. The template must be retired and not in use

## 💭 Motivation and context ##

CPD-182 - Allow for deletion of templates.

## 🧪 Testing ##

Tested locally against multiple templates. Templates in active use by a subscription, templates that are no longer in active use but are tied to the reporting/statistics of previous subscriptions, and templates that are not in use at all.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
