### PR TITLE
Template creation error message & cycle target count display

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
@@ -16,7 +16,7 @@
         >
           <mat-option *ngFor="let c of subscription.cycles" [value]="c">
             {{ c.start_date | UTCtoReadableTime }} -
-            {{ c.end_date | UTCtoReadableTime }}</mat-option
+            {{ c.end_date | UTCtoReadableTime }} ({{c.total_targets}})</mat-option
           >
         </mat-select>
       </mat-form-field>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
@@ -16,7 +16,9 @@
         >
           <mat-option *ngFor="let c of subscription.cycles" [value]="c">
             {{ c.start_date | UTCtoReadableTime }} -
-            {{ c.end_date | UTCtoReadableTime }} ({{c.total_targets}})</mat-option
+            {{ c.end_date | UTCtoReadableTime }} ({{
+              c.total_targets
+            }})</mat-option
           >
         </mat-select>
       </mat-form-field>

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -448,7 +448,6 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
             this.router.navigate(['/templates']);
           },
           (error: any) => {
-            console.log(error)
             this.dialog.open(AlertComponent, {
               // Parse error here
               data: {

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -448,11 +448,12 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
             this.router.navigate(['/templates']);
           },
           (error: any) => {
+            console.log(error)
             this.dialog.open(AlertComponent, {
               // Parse error here
               data: {
-                title: 'Template Error',
-                messageText: error.error,
+                title: `Template Error - ${error.statusText}`,
+                messageText: error.error.error,
               },
             });
           }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update the error message that is displayed when a duplicate template is attempted to be created. 

Added the target count to the individual cycles on the statistics page.

## 💭 Motivation and context ##

Correct error message displayed on attempted duplicate template creation .

## 🧪 Testing ##

Tested attempting to create duplicate templates

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] All new and existing tests pass.
