### PR TITLE
Template sort and template attributes on template selection

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.html
@@ -16,7 +16,9 @@
         >
           <mat-option *ngFor="let c of subscription.cycles" [value]="c">
             {{ c.start_date | UTCtoReadableTime }} -
-            {{ c.end_date | UTCtoReadableTime }} ({{c.total_targets}})</mat-option
+            {{ c.end_date | UTCtoReadableTime }} ({{
+              c.total_targets
+            }})</mat-option
           >
         </mat-select>
       </mat-form-field>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -1,6 +1,6 @@
 <div class="modal-container">
   <h1 mat-dialog-title>Select {{ decep_level | titlecase }} Tempalates</h1>
-  <div mat-dialog-content>
+  <div mat-dialog-content style="overflow:visible">
     <!-- Dialog Here -->
     <div class="section-container">
       <div class="left-section">
@@ -39,7 +39,7 @@
             ></mat-header-row>
             <mat-row
               class="table-row"
-              (click)="display(row.html)"
+              (click)="display(row)"
               *matRowDef="let row; columns: displayedColumnsSelected"
             ></mat-row>
           </mat-table>
@@ -77,7 +77,7 @@
             ></mat-header-row>
             <mat-row
               class="table-row"
-              (click)="display(row.html)"
+              (click)="display(row)"
               *matRowDef="let row; columns: displayedColumnsSelected"
             ></mat-row>
           </mat-table>
@@ -114,7 +114,7 @@
             ></mat-header-row>
             <mat-row
               class="table-row"
-              (click)="display(row.html)"
+              (click)="display(row)"
               *matRowDef="let row; columns: displayedColumnsAvailable"
             ></mat-row>
           </mat-table>
@@ -149,24 +149,46 @@
             ></mat-header-row>
             <mat-row
               class="table-row"
-              (click)="display(row.html)"
+              (click)="display(row)"
               *matRowDef="let row; columns: displayedColumnsAvailable"
             ></mat-row>
           </mat-table>
         </div>
       </div>
       <div class="right-section">
-        <div class="display-window" [innerHtml]="displayHTML"></div>
-        <div class="close-button">
-          <button
-            mat-button
-            color="primary"
-            [mat-dialog-close]="true"
-            cdkFocusInitial
-          >
-            Save
-          </button>
+        <div class="template-information">
+          <div>
+            <mat-label class="h6">Template Name</mat-label>
+            <div>
+              {{templateName}}
+            </div>
+          </div>
+          <div>
+            <mat-label class="h6">Subject</mat-label>
+            <div>
+              {{templateSubject}}
+            </div>
+          </div>
+          <div>
+            <mat-label class="h6">From Address</mat-label>
+            <div>
+              {{templateFromName}}
+            </div>
+          </div>
+          <hr>
+          <div class="display-window" [innerHtml]="displayHTML"></div>
         </div>
+      </div>
+      <div class="close-button">
+        <button
+          style="bottom:2em"
+          mat-button
+          color="primary"
+          [mat-dialog-close]="true"
+          cdkFocusInitial
+        >
+          Save
+        </button>
       </div>
     </div>
   </div>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -156,7 +156,6 @@
         </div>
       </div>
       <div class="right-section">
-
         <div *ngIf="!templateSelected" class="template-information">
           Please click a template to view a preview of it
         </div>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -1,6 +1,6 @@
 <div class="modal-container">
   <h1 mat-dialog-title>Select {{ decep_level | titlecase }} Tempalates</h1>
-  <div mat-dialog-content style="overflow:visible">
+  <div mat-dialog-content style="overflow: visible">
     <!-- Dialog Here -->
     <div class="section-container">
       <div class="left-section">
@@ -160,28 +160,28 @@
           <div>
             <mat-label class="h6">Template Name</mat-label>
             <div>
-              {{templateName}}
+              {{ templateName }}
             </div>
           </div>
           <div>
             <mat-label class="h6">Subject</mat-label>
             <div>
-              {{templateSubject}}
+              {{ templateSubject }}
             </div>
           </div>
           <div>
             <mat-label class="h6">From Address</mat-label>
             <div>
-              {{templateFromName}}
+              {{ templateFromName }}
             </div>
           </div>
-          <hr>
+          <hr />
           <div class="display-window" [innerHtml]="displayHTML"></div>
         </div>
       </div>
       <div class="close-button">
         <button
-          style="bottom:2em"
+          style="bottom: 2em"
           mat-button
           color="primary"
           [mat-dialog-close]="true"

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -156,7 +156,11 @@
         </div>
       </div>
       <div class="right-section">
-        <div class="template-information">
+
+        <div *ngIf="!templateSelected" class="template-information">
+          Please click a template to view a preview of it
+        </div>
+        <div *ngIf="templateSelected" class="template-information">
           <div>
             <mat-label class="h6">Template Name</mat-label>
             <div>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
@@ -9,19 +9,19 @@
 .left-section {
   flex-direction: column;
   height: 46em;
+  flex-basis: 42em;
 }
 
 .right-section {
-  border: solid 1px green;
-  margin: 1em;
+  // border: solid 1px rgb(60, 111, 142);
+  margin: 1em 1em 0em 1em;
   flex-direction: column;
-  margin-bottom: 8em;
+  // margin-bottom: 8em;
 }
 .close-button {
   display: flex;
   align-self: flex-end;
-  margin-bottom: -3em;
-  margin-top: 1em;
+  margin-left: -5em;
 }
 
 .modal-container {
@@ -77,4 +77,18 @@
 }
 .display-window {
   height: 100%;
+}
+
+.template-information{
+  margin-bottom: 2em;
+  padding-bottom: 2em;
+  overflow-y: scroll;
+}
+
+.template-information div div{
+  margin-left: 1em;
+}
+
+.mat-dialog-container {
+  overflow:visible !important;
 }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
@@ -79,16 +79,16 @@
   height: 100%;
 }
 
-.template-information{
+.template-information {
   margin-bottom: 2em;
   padding-bottom: 2em;
   overflow-y: scroll;
 }
 
-.template-information div div{
+.template-information div div {
   margin-left: 1em;
 }
 
 .mat-dialog-container {
-  overflow:visible !important;
+  overflow: visible !important;
 }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
@@ -35,7 +35,7 @@ export class TemplateSelectDialogComponent {
   templateName = '';
   templateSubject = '';
   templateFromName = '';
-  templateSelected : Boolean = false;
+  templateSelected: Boolean = false;
 
   displayedColumnsSelected = ['name', 'deception_score', 'remove'];
   displayedColumnsAvailable = ['name', 'deception_score', 'add'];
@@ -94,7 +94,7 @@ export class TemplateSelectDialogComponent {
   };
 
   display(template: Template) {
-    this.templateSelected = true
+    this.templateSelected = true;
     console.log(template);
     var re = '<%URL%>';
     this.displayHTML = template.html.replace(re, 'javascript:void(0)');

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
@@ -93,13 +93,12 @@ export class TemplateSelectDialogComponent {
   };
 
   display(template: Template) {
-    console.log(template)
+    console.log(template);
     var re = '<%URL%>';
     this.displayHTML = template.html.replace(re, 'javascript:void(0)');
-    
+
     this.templateName = template.name;
     this.templateSubject = template.subject;
     this.templateFromName = template.from_address;
-
   }
 }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
@@ -32,6 +32,9 @@ export class TemplateSelectDialogComponent {
     this.initMatTables();
   }
   displayHTML = '';
+  templateName = '';
+  templateSubject = '';
+  templateFromName = '';
 
   displayedColumnsSelected = ['name', 'deception_score', 'remove'];
   displayedColumnsAvailable = ['name', 'deception_score', 'add'];
@@ -89,10 +92,14 @@ export class TemplateSelectDialogComponent {
     this.avaiableList.filter = value.trim().toLocaleLowerCase();
   };
 
-  display(html) {
+  display(template: Template) {
+    console.log(template)
     var re = '<%URL%>';
-    this.displayHTML = html.replace(re, 'javascript:void(0)');
+    this.displayHTML = template.html.replace(re, 'javascript:void(0)');
+    
+    this.templateName = template.name;
+    this.templateSubject = template.subject;
+    this.templateFromName = template.from_address;
 
-    console.log(html);
   }
 }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.ts
@@ -35,6 +35,7 @@ export class TemplateSelectDialogComponent {
   templateName = '';
   templateSubject = '';
   templateFromName = '';
+  templateSelected : Boolean = false;
 
   displayedColumnsSelected = ['name', 'deception_score', 'remove'];
   displayedColumnsAvailable = ['name', 'deception_score', 'add'];
@@ -93,6 +94,7 @@ export class TemplateSelectDialogComponent {
   };
 
   display(template: Template) {
+    this.templateSelected = true
     console.log(template);
     var re = '<%URL%>';
     this.displayHTML = template.html.replace(re, 'javascript:void(0)');

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
@@ -48,7 +48,7 @@ export class TemplatesPageComponent implements OnInit, AfterViewInit {
       this.showRetired
     );
     this.templatesData.sort = this.sort;
-    const sortState: Sort = {active: 'deception_score', direction: 'asc'};
+    const sortState: Sort = { active: 'deception_score', direction: 'asc' };
     this.sort.active = sortState.active;
     this.sort.direction = sortState.direction;
     this.sort.sortChange.emit(sortState);

--- a/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
+++ b/src/AdminUI/src/app/components/templates-page/templates-page.component.ts
@@ -4,7 +4,7 @@ import { LayoutMainService } from 'src/app/services/layout-main.service';
 import { TemplateManagerService } from 'src/app/services/template-manager.service';
 import { Template } from 'src/app/models/template.model';
 import { MatTableDataSource } from '@angular/material/table';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 import { MatDialog } from '@angular/material/dialog';
 import { AlertComponent } from 'src/app/components/dialogs/alert/alert.component';
 
@@ -48,6 +48,10 @@ export class TemplatesPageComponent implements OnInit, AfterViewInit {
       this.showRetired
     );
     this.templatesData.sort = this.sort;
+    const sortState: Sort = {active: 'deception_score', direction: 'asc'};
+    this.sort.active = sortState.active;
+    this.sort.direction = sortState.direction;
+    this.sort.sortChange.emit(sortState);
     this.loading = false;
   }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Template sort on the template list page defaults to deception score.

Template attributes now displayed on the subscription configuration page template select dialog.

## 💭 Motivation and context ##

CPD-240 and CPD-244

## 🧪 Testing ##

Tested locally to ensure that sorting occurs by default in the correct order.

Test template info displaying correctly. Test for correct styling on change of page size.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
