### PR TITLE
CPD-255 User-defined cooldown period

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -356,11 +356,13 @@
           {{ subscription.target_email_list_cached_copy.length }}</em
         >
       </div>
-      <mat-label class="h6">Cycle Run Length</mat-label>
-      <div class="mb-4">
-        <div class="text-muted" *ngIf="sendingProfiles.length > 0">
-          The time that the cycle will take to run. (Must be between 15 minutes
-          and 360 days)
+      <!-- Email Sent Time -->
+      <mat-label class="h6">Sending Strategy</mat-label>
+      <mat-label class="h7">Email Sent Time</mat-label>
+      <div class="mb-2">
+        <div class="text-muted">
+          The time that all emails will be sent within. (Must be between 15
+          minutes and 360 days)
         </div>
         <mat-form-field appearance="outline">
           <mat-label>Time</mat-label>
@@ -402,9 +404,45 @@
           </mat-checkbox>
         </div>
       </div>
+      <!-- Cooldown Period -->
+      <mat-label class="h7">Cooldown Period</mat-label>
+      <div class="mb-4">
+        <div class="text-muted">
+          The amount of time that links stay active to allow for user clicks.
+          (Must be between 15 minutes and 360 days)
+        </div>
+        <mat-form-field appearance="outline">
+          <mat-label>Time</mat-label>
+          <input
+            matInput
+            formControlName="cooldownDisplayTime"
+            type="text"
+            trim="blur"
+          />
+          <mat-error
+            *ngIf="f.cooldownDisplayTime.errors?.outOfRange"
+            class="invalid-feedback"
+          >
+            Must be between 15 minutes and 360 days
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Time Units</mat-label>
+          <mat-select formControlName="cooldownTimeUnit">
+            <mat-option *ngFor="let time of timeRanges" [value]="time">
+              {{ time }}</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+        <div class="text-muted">
+          All emails will be sent by {{ sendBy | date: "long" }} and the cycle
+          will be completed on {{ endDate | date: "long" }}.
+        </div>
+      </div>
+      <!-- Status Report Frequency -->
       <mat-label class="h6">Status Report Frequency</mat-label>
       <div class="mb-4">
-        <div class="text-muted" *ngIf="sendingProfiles.length > 0">
+        <div class="text-muted">
           The frequency at which the status report is sent out to the customer
           and CISA contact for this subscription. (Must be between 15 minutes
           and 360 days)
@@ -424,7 +462,7 @@
             Must be between 15 minutes and 360 days
           </mat-error>
         </mat-form-field>
-        <mat-form-field appearance="outline" *ngIf="sendingProfiles.length > 0">
+        <mat-form-field appearance="outline">
           <mat-label>Time Units</mat-label>
           <mat-select formControlName="reportTimeUnit">
             <mat-option *ngFor="let time of timeRanges" [value]="time">

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
@@ -148,7 +148,6 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
           this.aggregateCounts = stats['aggregate_stats'];
           this.campaignsDetails = stats['campaign_details'];
           this.ipAsnStats = stats.asn_stats;
-          console.log(this.ipAsnStats);
         });
     }
   }

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -57,6 +57,7 @@ export class Subscription {
   continuous_subscription: boolean;
   email_report_history: EmailHistory[] = [];
   cycle_length_minutes: number;
+  cooldown_minutes: number;
   report_frequency_minutes: number;
   templates_selected: TemplateSelected;
 }

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -138,6 +138,7 @@ export class SubscriptionService {
       continuous_subscription: subscription.continuous_subscription,
       templates_selected: subscription.templates_selected,
       cycle_length_minutes: subscription.cycle_length_minutes,
+      cooldown_minutes: subscription.cooldown_minutes,
       report_frequency_minutes: subscription.report_frequency_minutes,
     };
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Allows a user to define the cooldown period for a subscription.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Before, the cooldown period was calculated as a third of the subscription time. This met original requirements for most subscriptions running for 3 months with a 1 month period no emails would be sent. Now, these cooldown periods only need to be a couple days in some cases. This allows that cooldown period to be uniquely defined from subscription to subscription.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Ran a couple subscriptions locally and ran/modified pytests to make sure everything was working properly.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
