### PR TITLE
Add template selected/available count to selection dialog

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -23,7 +23,9 @@
     <div class="section-container">
       <div class="left-section">
         <div class="template-selected-list">
-          <div class="template-table-title"> Selected ({{this.selectedArray.length}})</div>
+          <div class="template-table-title">
+            Selected ({{ this.selectedArray.length }})
+          </div>
           <mat-table class="header-table" [dataSource]="emptyList">
             <!-- Template Name -->
             <ng-container matColumnDef="name">
@@ -101,7 +103,9 @@
           </mat-table>
         </div>
         <div class="template-available-list">
-          <div class="template-table-title">Available ({{this.availableArray.length}})</div>
+          <div class="template-table-title">
+            Available ({{ this.availableArray.length }})
+          </div>
           <mat-table class="header-table" [dataSource]="emptyList">
             <!-- Template Name -->
             <ng-container matColumnDef="name">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.html
@@ -23,7 +23,7 @@
     <div class="section-container">
       <div class="left-section">
         <div class="template-selected-list">
-          <div class="template-table-title">Selected</div>
+          <div class="template-table-title"> Selected ({{this.selectedArray.length}})</div>
           <mat-table class="header-table" [dataSource]="emptyList">
             <!-- Template Name -->
             <ng-container matColumnDef="name">
@@ -101,7 +101,7 @@
           </mat-table>
         </div>
         <div class="template-available-list">
-          <div class="template-table-title">Available</div>
+          <div class="template-table-title">Available ({{this.availableArray.length}})</div>
           <mat-table class="header-table" [dataSource]="emptyList">
             <!-- Template Name -->
             <ng-container matColumnDef="name">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/template-select-dialog/template-select-dialog.component.scss
@@ -66,7 +66,7 @@
   margin: auto;
 }
 .template-table-title {
-  width: 5em;
+  width: 6em;
   display: flex;
 }
 .mat-dialog-container {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Add template count for the available and selected templates list on the select template dialog.

## 💭 Motivation and context ##

CPD-263 : Show the template selected/available count on the selection dialog.

## 🧪 Testing ##

Tested locally to ensure the count displays, displays the correct count, and does not affect styling of the dialog.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
