### PR TITLE
Prevent the actions list from displaying incorrectly on subscription save.

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -804,6 +804,7 @@ export class SubscriptionConfigTab
     if (!this.subValid()) {
       return;
     }
+    console.log(this.subscription.status);
 
     const sub = this.subscriptionSvc.subscription;
 
@@ -817,7 +818,6 @@ export class SubscriptionConfigTab
       this.f.startDate.setValue(new Date(this.f.startDate.value));
     }
     sub.start_date = this.f.startDate.value;
-    sub.status = 'Queued';
 
     // set the target list
     const csv = this.f.csvText.value;

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -804,7 +804,6 @@ export class SubscriptionConfigTab
     if (!this.subValid()) {
       return;
     }
-    console.log(this.subscription.status);
 
     const sub = this.subscriptionSvc.subscription;
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Removed a line that changed the status of a subscription to queued. Was an artifact of when saving the subscription would automatically start on save. With the new method of saving and launching separately, it is no longer needed and was causing errors. 

## 💭 Motivation and context ##

CPD - 261 : Subscriptions shows stop subscription after saving. Changes made prevent this from happening


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
