### PR TITLE
CPD-259 Best performing templates on stats page

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-stats-tab/subscription-stats-tab.component.ts
@@ -31,6 +31,7 @@ export class SubscriptionStatsTab implements OnInit {
   subscription_uuid: string;
   selectedCycle: Cycle;
   timelineItems: any[] = [];
+  templateRanking: any[] = [];
   reportedStatsForm: FormGroup;
   invalidDateTimeObject: String;
   reportsData: any;

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
@@ -78,6 +78,28 @@
         </ul>
       </div>
       <div>
+        Template Performance Breakdown
+        <div class="metric-button-container">
+          <button
+            *ngFor="let metric of templatesByPerformance"
+            [style.border]="styleSelectedMetric(metric.type)"
+            (click)="selectTemplatePerformanceMetric(metric.type)"
+            class="metric-button"
+          >
+            {{ metric.type | titlecase }}</button
+          >:
+        </div>
+        <ul>
+          <li *ngFor="let row of templatePerformanceByMetric">
+            {{ row.order }} - {{ row.template.name }}
+            <a
+              [routerLink]="['/templatemanager', row.template.template_uuid]"
+              >{{ row.template.subject }}</a
+            >
+          </li>
+        </ul>
+      </div>
+      <div>
         IP Address / ASN Org Breakdown:
         <table class="table">
           <tr>

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
@@ -91,7 +91,7 @@
         </div>
         <ul>
           <li *ngFor="let row of templatePerformanceByMetric">
-            {{ row.order }} - {{ row.template.name }}
+            {{ row.order }} - {{getRatio(row.ratios) | percent}} - {{ row.template.name }}
             <a
               [routerLink]="['/templatemanager', row.template.template_uuid]"
               >{{ row.template.subject }}</a

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.html
@@ -91,7 +91,8 @@
         </div>
         <ul>
           <li *ngFor="let row of templatePerformanceByMetric">
-            {{ row.order }} - {{getRatio(row.ratios) | percent}} - {{ row.template.name }}
+            {{ row.order }} - {{ getRatio(row.ratios) | percent }} -
+            {{ row.template.name }}
             <a
               [routerLink]="['/templatemanager', row.template.template_uuid]"
               >{{ row.template.subject }}</a

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.scss
@@ -19,3 +19,28 @@
   max-width: 20em;
   word-break: break-word;
 }
+.metric-button-container {
+  display: inline;
+}
+
+.metric-button:first-child {
+  border-top-left-radius: 14px;
+  border-bottom-left-radius: 14px;
+  border-right: solid 2px white;
+}
+.metric-button:last-child {
+  border-bottom-right-radius: 14px;
+  border-top-right-radius: 14px;
+  border-left: solid 2px white;
+}
+
+.metric-button {
+  background: #29ab87;
+  border: solid white 2px;
+  padding: 0 1.5em;
+  color: white;
+}
+.metric-button:hover {
+  background: #18654f;
+  color: white;
+}

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
@@ -46,6 +46,9 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
   selected_cycle: Cycle;
 
   temp_angular_subs = [];
+  templatesByPerformance = [];
+  templatePerformanceByMetric = [];
+  performanceMetricUsed = 'clicked';
 
   /**
    *
@@ -136,8 +139,9 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
           this.chart.chartResults = this.chartsSvc.formatStatistics(stats);
           this.chartSent.chartResults =
             this.chartsSvc.getSentEmailNumbers(stats);
-
+          this.templatesByPerformance = stats.template_breakdown;
           this.avgTTFC = stats.avg_time_to_first_click;
+          this.selectTemplatePerformanceMetric();
           if (!this.avgTTFC) {
             this.avgTTFC = '(no emails clicked yet)';
           }
@@ -161,6 +165,20 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
       return val.toLocaleString();
     } else {
       return '';
+    }
+  }
+
+  selectTemplatePerformanceMetric(metric = 'clicked') {
+    this.performanceMetricUsed = metric;
+    this.templatesByPerformance.forEach((e) => {
+      if (e.type == this.performanceMetricUsed) {
+        this.templatePerformanceByMetric = e.list;
+      }
+    });
+  }
+  styleSelectedMetric(metric) {
+    if (this.performanceMetricUsed == metric) {
+      return 'solid 2px #D6C0C5';
     }
   }
 }

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
@@ -181,8 +181,8 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
       return 'solid 2px #D6C0C5';
     }
   }
-  getRatio(ratios){
-    let selectedString = `${this.performanceMetricUsed}_ratio`
-    return ratios[selectedString]
+  getRatio(ratios) {
+    let selectedString = `${this.performanceMetricUsed}_ratio`;
+    return ratios[selectedString];
   }
 }

--- a/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/sub-dashboard/sub-dashboard.component.ts
@@ -181,4 +181,8 @@ export class SubDashboardComponent implements OnInit, OnDestroy {
       return 'solid 2px #D6C0C5';
     }
   }
+  getRatio(ratios){
+    let selectedString = `${this.performanceMetricUsed}_ratio`
+    return ratios[selectedString]
+  }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Display the best performing templates on the stats page. Allow for selection of clicked, opened, or submitted as the metric for performance. Display the information in an ordered list with percent based performance included.

## 💭 Motivation and context ##

CPD-259 : Display the best performing template data on the stats page.

## 🧪 Testing ##

Tested against multiple local subscriptions and there test data.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.