### PR TITLE
Show end times of running subscriptions

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -372,9 +372,6 @@ export class SubscriptionConfigTab
     if (typeof start === 'string') {
       start = new Date(this.f.startDate.value);
     }
-    if (start < new Date()) {
-      start = new Date();
-    }
     const cycleLength: number = +this.f.cycle_length_minutes.value;
     const cooldownLength: number = +this.f.cooldown_minutes.value;
     this.sendBy = new Date(start);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
On running subscriptions, if the start date was less than current date, the current date was used and end times would display improperly. Removed that logic.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
So end times are displayed properly for future reference.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Made sure old subscriptions date and times displayed properly.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
