### PR TITLE
Subscription Reporting Password

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -151,6 +151,22 @@
         </div>
       </div>
 
+      <mat-form-field appearance="outline" style="max-width: 33rem">
+        <mat-label>Reporting Password</mat-label>
+        <input
+          matInput
+          formControlName="reportingPassword"
+          [type]="hideReportingPassword ? 'password' : 'text'"
+        />
+        <mat-icon
+          matSuffix
+          (click)="hideReportingPassword = !hideReportingPassword"
+          >{{
+            hideReportingPassword ? "visibility_off" : "visibility"
+          }}</mat-icon
+        >
+      </mat-form-field>
+
       <mat-label *ngIf="subscription.templates_selected" class="h6"
         >Template Selection
         <mat-icon

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -107,6 +107,8 @@ export class SubscriptionConfigTab
   loading = true;
   loadingText = 'Loading Subscription';
 
+  hideReportingPassword = true;
+
   @Input() showLoading: boolean;
   ngOnChanges(changes: SimpleChanges) {
     if (changes.showLoading) {
@@ -199,6 +201,7 @@ export class SubscriptionConfigTab
         reportTimeUnit: new FormControl('Minutes'),
         reportDisplayTime: new FormControl(43200),
         continuousSubscription: new FormControl(false, {}),
+        reportingPassword: new FormControl(''),
       },
       { updateOn: 'blur' }
     );
@@ -276,6 +279,11 @@ export class SubscriptionConfigTab
     this.angular_subs.push(
       this.f.continuousSubscription.valueChanges.subscribe((val) => {
         this.subscription.continuous_subscription = val;
+      })
+    );
+    this.angular_subs.push(
+      this.f.reportingPassword.valueChanges.subscribe((val) => {
+        this.subscription.reporting_password = val;
       })
     );
 
@@ -507,6 +515,7 @@ export class SubscriptionConfigTab
       emitEvent: false,
     });
     this.f.continuousSubscription.setValue(s.continuous_subscription);
+    this.f.reportingPassword.setValue(s.reporting_password);
     this.enableDisableFields();
 
     this.customerSvc
@@ -825,6 +834,7 @@ export class SubscriptionConfigTab
     sub.sending_profile_id = this.f.sendingProfile.value;
 
     sub.continuous_subscription = this.f.continuousSubscription.value;
+    sub.reporting_password = this.f.reportingPassword.value;
     const cycleLength: number = +this.f.cycle_length_minutes.value;
     const cooldownLength: number = +this.f.cooldown_minutes.value;
     const reportLength: number = +this.f.report_frequency_minutes.value;

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -46,6 +46,7 @@ export class SubscriptionModel {
   tasks: TaskModel[];
   notification_history: SubscriptionNotificationModel[];
   phish_header: string;
+  reporting_password: string;
 
   // Helper attributes
   cycles: CycleModel[];

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -106,6 +106,7 @@ export class SubscriptionService {
       cycle_length_minutes: subscription.cycle_length_minutes,
       cooldown_minutes: subscription.cooldown_minutes,
       report_frequency_minutes: subscription.report_frequency_minutes,
+      reporting_password: subscription.reporting_password,
     };
 
     return this.http.put(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Adds a field to set reporting password on a subscription.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Requirement to password protect sent reports.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Local.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
