### PR TITLE
Fix template testing tab sizes

### DIFF
--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.html
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.html
@@ -303,7 +303,7 @@
           </mat-tab>
           <mat-tab>
             <ng-template mat-tab-label> Template Testing </ng-template>
-            <div class="p-3">
+            <div class="p-3 flex-column" [style.height.px]="text_editor_height">
               <mat-label class="h6">Sending Profile</mat-label>
               <div class="mb-4">
                 <div class="text-muted" *ngIf="sendingProfiles.length > 0">
@@ -440,7 +440,7 @@
                   class="d-flex flex-grow-1"
                   [src]="mailtester_iframe_url"
                   title="Testing results"
-                  [style.height.px]="iframe_height"
+                  [style.height.px]="350"
                 ></iframe>
               </div>
             </div>

--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -95,7 +95,6 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
   body_content_height: number;
   text_editor_height: number;
   text_editor_height2: number;
-  iframe_height: number;
   text_area_bot_marg: number = 20; // based on the default text area padding on a mat textarea element
   angular_editor_mode: String = 'WYSIWYG';
 
@@ -585,7 +584,6 @@ export class TemplateManagerComponent implements OnInit, AfterViewInit {
       mat_text_area_height -
       save_button_row_height;
     this.text_editor_height2 = this.text_editor_height;
-    this.iframe_height = this.text_editor_height - 550;
 
     //Get the angular-editor toolbar height as it changes when the buttons wrap
     let angular_editor_tool_bar_height =


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Fixes sizes of iframe on template testing tab by making container scrollable.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Couldn't see results of test.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Local.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
