### PR TITLE
feature: cpd-713 disable lpd field in sending profile and hyperlink from template testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @dylanj1752 @felddy @INLGuy @itsmostafa @jsf9k @mcdonnnj @zenine07
+* @dav3r @dylanj1752 @felddy @INLGuy @itsmostafa @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
+++ b/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
@@ -75,6 +75,27 @@
             Customer/Organization identifier may not contain only spaces
           </mat-error>
         </mat-form-field>
+        <mat-form-field
+          appearance="outline"
+          class="flex-grow-1"
+          [formGroup]="customerFormGroup"
+        >
+          <mat-label>Appendix A Date</mat-label>
+          <input
+            matInput
+            formControlName="appendixADate"
+            [matDatepicker]="picker"
+            [min]=""
+          />
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="picker"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #picker [startAt]="startAt"></mat-datepicker>
+          <!-- <mat-error *ngIf="appendixADate.errors?.matDatepickerMin" class="invalid-feedback">
+            Appendix A Date cannot be in the past
+          </mat-error> -->
+        </mat-form-field>
       </div>
 
       <!-- Domain -->
@@ -270,8 +291,8 @@
           >
             <mat-option [value]="null">--Select--</mat-option>
             <mat-option *ngFor="let s of sectorList" [value]="s.name">
-              {{ s.name }}</mat-option
-            >
+              {{ s.name }}
+            </mat-option>
           </mat-select>
           <mat-error
             *ngIf="customerFormGroup.controls.sector.hasError('required')"
@@ -289,14 +310,14 @@
           <mat-label>Industry</mat-label>
           <mat-select formControlName="industry">
             <mat-option *ngIf="!sectorSelected()" [value]="null">
-              <b>Select a sector</b></mat-option
-            >
+              <b>Select a sector</b>
+            </mat-option>
             <mat-option *ngIf="sectorSelected()" [value]="null"
               >--Select--</mat-option
             >
             <mat-option *ngFor="let s of industryList" [value]="s.name">
-              {{ s.name }}</mat-option
-            >
+              {{ s.name }}
+            </mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
+++ b/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.html
@@ -92,9 +92,6 @@
             [for]="picker"
           ></mat-datepicker-toggle>
           <mat-datepicker #picker [startAt]="startAt"></mat-datepicker>
-          <!-- <mat-error *ngIf="appendixADate.errors?.matDatepickerMin" class="invalid-feedback">
-            Appendix A Date cannot be in the past
-          </mat-error> -->
         </mat-form-field>
       </div>
 

--- a/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
+++ b/src/AdminUI/src/app/components/customer/add-customer/add-customer.component.ts
@@ -49,6 +49,8 @@ export class AddCustomerComponent
   isEdit = false;
   tempEditContact: ContactModel = null;
 
+  startAt = new Date();
+
   matchCustomerName = new MyErrorStateMatcher();
   matchCustomerIdentifier = new MyErrorStateMatcher();
   matchAddress1 = new MyErrorStateMatcher();
@@ -73,6 +75,7 @@ export class AddCustomerComponent
     industry: new FormControl(null),
     customerType: new FormControl('', [Validators.required]),
     domain: new FormControl('', [Validators.required]),
+    appendixADate: new FormControl(new Date(), [Validators.required]),
   });
 
   contactFormGroup = new FormGroup({
@@ -201,6 +204,7 @@ export class AddCustomerComponent
       sector: customer.sector,
       industry: customer.industry,
       domain: customer.domain,
+      appendixADate: customer.appendix_a_date,
     });
   }
 
@@ -272,6 +276,7 @@ export class AddCustomerComponent
         customer_type: this.customerFormGroup.controls['customerType'].value,
         contact_list: this.contacts.data,
         domain: this.customerFormGroup.controls['domain'].value,
+        appendix_a_date: this.customerFormGroup.controls['appendixADate'].value,
       };
 
       if (this.customer_id != null) {

--- a/src/AdminUI/src/app/components/sending-profiles/sending-profile-detail.component.ts
+++ b/src/AdminUI/src/app/components/sending-profiles/sending-profile-detail.component.ts
@@ -58,6 +58,7 @@ export class SendingProfileDetailComponent implements OnInit {
    * convenience getter for easy access to form fields
    */
   get f() {
+    this.profileForm.controls['landingPageDomain'].disable();
     return this.profileForm.controls;
   }
 
@@ -67,7 +68,7 @@ export class SendingProfileDetailComponent implements OnInit {
   ngOnInit(): void {
     this.profileForm = new FormGroup({
       name: new FormControl('', Validators.required),
-      landingPageDomain: new FormControl('', Validators.required),
+      landingPageDomain: new FormControl(''),
       interfaceType: new FormControl('SMTP', Validators.required),
       from: new FormControl('', [
         Validators.required,

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.html
@@ -108,12 +108,20 @@
       </mat-cell>
     </ng-container>
 
+    <!-- Sent Date -->
+    <ng-container matColumnDef="sent_date">
+      <mat-header-cell *matHeaderCellDef>Sent Date</mat-header-cell>
+      <mat-cell *matCellDef="let row">
+        {{ row.sent_date | date: "medium" }}
+      </mat-cell>
+    </ng-container>
+
     <!-- Sent -->
     <ng-container matColumnDef="sent">
       <mat-header-cell *matHeaderCellDef>Sent</mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <mat-icon *ngIf="row.sent" color="primary">check_circle</mat-icon
-        ><mat-icon *ngIf="!row.sent" color="warn">error</mat-icon>
+        <mat-icon *ngIf="row.sent" color="primary">check_circle</mat-icon>
+        <mat-icon *ngIf="!row.sent" color="warn">error</mat-icon>
       </mat-cell>
     </ng-container>
 
@@ -121,8 +129,8 @@
     <ng-container matColumnDef="clicked">
       <mat-header-cell *matHeaderCellDef>Clicked</mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <mat-icon *ngIf="row.clicked" color="primary">check_circle</mat-icon
-        ><mat-icon *ngIf="!row.clicked" color="warn">error</mat-icon>
+        <mat-icon *ngIf="row.clicked" color="primary">check_circle</mat-icon>
+        <mat-icon *ngIf="!row.clicked" color="warn">error</mat-icon>
       </mat-cell>
     </ng-container>
 
@@ -131,7 +139,8 @@
     <mat-row
       *matRowDef="let row; columns: resultColumns"
       class="table-row cursor-pointer"
-      (click)="detailResults(row)"
-    ></mat-row>
+      (click)="toTemplateDetails(row)"
+    >
+    </mat-row>
   </mat-table>
 </mat-card>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
@@ -114,21 +114,6 @@ export class SubscriptionTestingTabComponent implements OnInit {
     this.router.navigate(['/templatemanager', result.template._id]);
   }
 
-  // detailResults(result: SubscriptionTestResultsModel) {
-  //   this.dialog.open(GenericViewComponent, {
-  //     data: {
-  //       email: result.email,
-  //       template: result.template.name,
-  //       subject: result.template.subject,
-  //       timeline: result.timeline,
-  //       sent: result.sent,
-  //       sentDate: result.sent_date,
-  //       opened: result.opened,
-  //       clicked: result.clicked,
-  //     },
-  //   });
-  // }
-
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
     const numSelected = this.selection.selected.length;

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
@@ -29,7 +29,7 @@ export class SubscriptionTestingTabComponent implements OnInit {
 
   contactColumns = ['select', 'email', 'firstName', 'lastName'];
 
-  resultColumns = ['template', 'email', 'sent', 'clicked'];
+  resultColumns = ['template', 'email', 'sent', 'sent_date', 'clicked'];
 
   contactList: ContactModel[];
 
@@ -110,20 +110,24 @@ export class SubscriptionTestingTabComponent implements OnInit {
       });
   }
 
-  detailResults(result: SubscriptionTestResultsModel) {
-    this.dialog.open(GenericViewComponent, {
-      data: {
-        email: result.email,
-        template: result.template.name,
-        subject: result.template.subject,
-        timeline: result.timeline,
-        sent: result.sent,
-        sentDate: result.sent_date,
-        opened: result.opened,
-        clicked: result.clicked,
-      },
-    });
+  toTemplateDetails(result: SubscriptionTestResultsModel) {
+    this.router.navigate(['/templatemanager', result.template._id]);
   }
+
+  // detailResults(result: SubscriptionTestResultsModel) {
+  //   this.dialog.open(GenericViewComponent, {
+  //     data: {
+  //       email: result.email,
+  //       template: result.template.name,
+  //       subject: result.template.subject,
+  //       timeline: result.timeline,
+  //       sent: result.sent,
+  //       sentDate: result.sent_date,
+  //       opened: result.opened,
+  //       clicked: result.clicked,
+  //     },
+  //   });
+  // }
 
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {

--- a/src/AdminUI/src/app/models/customer.model.ts
+++ b/src/AdminUI/src/app/models/customer.model.ts
@@ -12,6 +12,7 @@ export class CustomerModel {
   customer_type: string;
   contact_list: ContactModel[];
   domain: string;
+  appendix_a_date: Date;
 
   public constructor(init?: Partial<CustomerModel>) {
     Object.assign(this, init);


### PR DESCRIPTION
## 🗣 Description ##
- Disable landing page domain field in sending profile to encourage using the landing page domain field in the subscription details view instead
- route to template details view when clicking on a template in email sent list in the subscription testing tab
- Add Appendix A Date field to Customer Edit Page

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
