### PR TITLE
fix: prevent start date from being set before appendix date

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -767,6 +767,13 @@
           >
             Report time must be between 15 minutes and 360 days
           </mat-error>
+          <mat-error
+            style="display: flex"
+            *ngIf="startBeforeAppendixDate"
+            class="invalid-feedback"
+          >
+            Start Date can not be before the Appendix A Date
+          </mat-error>
         </div>
       </div>
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -91,6 +91,8 @@ export class SubscriptionConfigTab
   startAt = new Date();
   sendBy = new Date();
   endDate = new Date();
+  appendixADate = new Date();
+  startBeforeAppendixDate = false;
 
   sendingProfiles = [];
 
@@ -270,6 +272,9 @@ export class SubscriptionConfigTab
         }
         this.subscription.start_date = startDate;
         this.setEndTimes();
+
+        // // Check if Start Date is before Appendix A Date
+        this.isStartDateBeforeAADate();
       })
     );
 
@@ -605,6 +610,8 @@ export class SubscriptionConfigTab
             (contact) => contact.active === true
           );
           this.f.selectedCustomerId.setValue(this.customer._id);
+          this.appendixADate = new Date(data.appendix_a_date);
+          this.isStartDateBeforeAADate();
         });
     }
   }
@@ -867,6 +874,10 @@ export class SubscriptionConfigTab
       return;
     }
 
+    if (this.startBeforeAppendixDate) {
+      return;
+    }
+
     this.loading = true;
     this.loadingText = 'Saving subscription';
 
@@ -1102,6 +1113,19 @@ export class SubscriptionConfigTab
       return null;
     };
   }
+
+  isStartDateBeforeAADate() {
+    if (this.customer) {
+      this.appendixADate = new Date(this.customer.appendix_a_date);
+    }
+    if (this.appendixADate && this.f.startDate.value < this.appendixADate) {
+      console.log('Start Date can not be before the Appendix A Date');
+      this.startBeforeAppendixDate = true;
+      return;
+    }
+    this.startBeforeAppendixDate = false;
+  }
+
   validDomain(control: FormControl) {
     const exprEmail =
       /^@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.html
@@ -2,9 +2,9 @@
   [showLoading]="launching"
   [displayText]="launchingText"
 ></app-loading-overlay>
-<mat-card>
+<mat-card *ngIf="!startBeforeAppendixDate; else disallow_testing">
   <mat-card-title>Configuration</mat-card-title>
-  <p>
+  <p class="mt-3">
     All templates will be sent to each of the following customer contacts. This
     will help verify proper safelisting configuration (emails can land in the
     targets' inboxes and that they can click on the links).
@@ -75,6 +75,19 @@
     </button>
   </div>
 </mat-card>
+<ng-template #disallow_testing>
+  <mat-card>
+    <mat-card-title>Configuration</mat-card-title>
+    <p class="mt-3">
+      All templates will be sent to each of the following customer contacts.
+      This will help verify proper safelisting configuration (emails can land in
+      the targets' inboxes and that they can click on the links).
+    </p>
+    <p>
+      <strong>Please check back after the Customer's Appendix A Date.</strong>
+    </p>
+  </mat-card>
+</ng-template>
 
 <mat-card *ngIf="testResults && testResults.length > 0">
   <mat-card-title

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-testing-tab/subscription-testing-tab.component.ts
@@ -36,6 +36,10 @@ export class SubscriptionTestingTabComponent implements OnInit {
   // Contact selection
   selection = new SelectionModel<ContactModel>(true, []);
 
+  // Appendix A Date
+  appendixADate = new Date();
+  startBeforeAppendixDate = false;
+
   constructor(
     public alertsService: AlertsService,
     public customerSvc: CustomerService,
@@ -57,6 +61,7 @@ export class SubscriptionTestingTabComponent implements OnInit {
             first_name: names[0],
             last_name: names[1],
           } as ContactModel);
+          this.isStartDateBeforeAADate();
         });
         this.getResults();
       }
@@ -126,5 +131,16 @@ export class SubscriptionTestingTabComponent implements OnInit {
     this.isAllSelected()
       ? this.selection.clear()
       : this.customer.contact_list.forEach((row) => this.selection.select(row));
+  }
+
+  // Start Date is before Appendix A Date
+  isStartDateBeforeAADate() {
+    this.appendixADate = new Date(this.customer.appendix_a_date);
+    if (this.subscription.start_date < this.appendixADate) {
+      console.log('Start Date can not be before the Appendix A Date');
+      this.startBeforeAppendixDate = true;
+      return;
+    }
+    this.startBeforeAppendixDate = false;
   }
 }


### PR DESCRIPTION
Add logic to prevent subscription start date to fall before the Appendix A Date
Disable testing tab until appendix A Date

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
