### PR TITLE
feature: cpd-728 prompt dialog when leaving page with dirty form

### DIFF
--- a/src/AdminUI/src/app/app-routing.module.ts
+++ b/src/AdminUI/src/app/app-routing.module.ts
@@ -41,7 +41,13 @@ const routes: Routes = [
     path: 'create-subscription',
     component: LayoutMainComponent,
     canActivate: [AuthGuard],
-    children: [{ path: '', component: SubscriptionConfigTab }],
+    children: [
+      {
+        path: '',
+        component: SubscriptionConfigTab,
+        canDeactivate: [UnsavedChangesGuard],
+      },
+    ],
   },
   {
     path: 'view-subscription',

--- a/src/AdminUI/src/app/app-routing.module.ts
+++ b/src/AdminUI/src/app/app-routing.module.ts
@@ -87,7 +87,13 @@ const routes: Routes = [
     path: 'customers',
     component: LayoutMainComponent,
     canActivate: [AuthGuard],
-    children: [{ path: '', component: CustomersComponent }],
+    children: [
+      {
+        path: '',
+        component: CustomersComponent,
+        canDeactivate: [UnsavedChangesGuard],
+      },
+    ],
   },
   {
     path: 'customer/:customerId',

--- a/src/AdminUI/src/app/app.module.ts
+++ b/src/AdminUI/src/app/app.module.ts
@@ -105,6 +105,7 @@ import { TemplatesDataService } from './services/templates-data.service';
 import { TestTemplatesDialogComponent } from './components/template-manager/test-templates-dialog/test-templates-dialog.component';
 import { LandingDomainsComponent } from './components/landing-domains/landing-domains.component';
 import { LandingDomainDetailComponent } from './components/landing-domains/landing-domain-detail/landing-domain-detail.component';
+import { NavigateAwayComponent } from './components/dialogs/navigate-away/navigate-away.component';
 
 export function app_Init(settingsHttpService: SettingsHttpService) {
   return () => settingsHttpService.initializeApp();
@@ -177,6 +178,7 @@ export function app_Init(settingsHttpService: SettingsHttpService) {
     TestTemplatesDialogComponent,
     LandingDomainsComponent,
     LandingDomainDetailComponent,
+    NavigateAwayComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/AdminUI/src/app/components/customers/customers.component.ts
+++ b/src/AdminUI/src/app/components/customers/customers.component.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { CustomerModel } from 'src/app/models/customer.model';
 import { Router } from '@angular/router';
 import { MatSort } from '@angular/material/sort';
+import { NavigateAwayComponent } from '../dialogs/navigate-away/navigate-away.component';
 
 @Component({
   selector: 'app-customers',
@@ -66,6 +67,29 @@ export class CustomersComponent implements OnInit {
       this.customersData.data = data as CustomerModel[];
       this.customersData.sort = this.sort;
       this.loading = false;
+    });
+  }
+
+  public canDeactivate(): Promise<boolean> {
+    return this.isNavigationAllowed();
+  }
+
+  private isNavigationAllowed(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      if (this.customerSvc.showCustomerInfo) {
+        const dialogRef = this.dialog.open(NavigateAwayComponent);
+        dialogRef.afterClosed().subscribe((result) => {
+          if (result === 'save') {
+            resolve(true);
+          } else if (result === 'discard') {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+      } else {
+        resolve(true);
+      }
     });
   }
 

--- a/src/AdminUI/src/app/components/dialogs/navigate-away/navigate-away.component.html
+++ b/src/AdminUI/src/app/components/dialogs/navigate-away/navigate-away.component.html
@@ -1,0 +1,23 @@
+<h1 mat-dialog-title>Unsaved Changes</h1>
+<div mat-dialog-content class="d-flex flex-column">
+  <div class="d-flex flex-row">
+    <mat-dialog-content class="mt-2 mb-2">
+      Are you sure you want to discard your changes?
+    </mat-dialog-content>
+  </div>
+</div>
+
+<div class="mt-2 mb-2 d-flex flex-row justify-content-end">
+  <mat-dialog-actions>
+    <button
+      mat-flat-button
+      color="warning"
+      (click)="dialogRef.close('discard')"
+    >
+      Discard Changes
+    </button>
+    <button mat-flat-button color="accent" (click)="dialogRef.close('cancel')">
+      Cancel
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/AdminUI/src/app/components/dialogs/navigate-away/navigate-away.component.ts
+++ b/src/AdminUI/src/app/components/dialogs/navigate-away/navigate-away.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-navigate-away',
+  templateUrl: './navigate-away.component.html',
+  styleUrls: ['./navigate-away.component.scss'],
+})
+export class NavigateAwayComponent implements OnInit {
+  constructor(public dialogRef: MatDialogRef<NavigateAwayComponent>) {}
+
+  ngOnInit(): void {}
+}

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -46,6 +46,7 @@ import { UserService } from 'src/app/services/user.service';
 import { UserModel } from 'src/app/models/user.model';
 import { TemplateModel } from 'src/app/models/template.model';
 import { SendingProfileModel } from 'src/app/models/sending-profile.model';
+import { NavigateAwayComponent } from 'src/app/components/dialogs/navigate-away/navigate-away.component';
 
 @Component({
   selector: 'subscription-config-tab',
@@ -237,17 +238,31 @@ export class SubscriptionConfigTab
   private isNavigationAllowed(): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       if (this.subscribeForm.dirty) {
-        this.dialogRefConfirm = this.dialog.open(UnsavedComponent);
-        this.dialogRefConfirm.afterClosed().subscribe((result) => {
-          if (result === 'save') {
-            this.save();
-            resolve(true);
-          } else if (result === 'discard') {
-            resolve(true);
-          } else {
-            resolve(false);
-          }
-        });
+        if (this.pageMode == 'CREATE') {
+          this.dialogRefConfirm = this.dialog.open(NavigateAwayComponent);
+          this.dialogRefConfirm.afterClosed().subscribe((result) => {
+            if (result === 'save') {
+              this.save();
+              resolve(true);
+            } else if (result === 'discard') {
+              resolve(true);
+            } else {
+              resolve(false);
+            }
+          });
+        } else {
+          this.dialogRefConfirm = this.dialog.open(UnsavedComponent);
+          this.dialogRefConfirm.afterClosed().subscribe((result) => {
+            if (result === 'save') {
+              this.save();
+              resolve(true);
+            } else if (result === 'discard') {
+              resolve(true);
+            } else {
+              resolve(false);
+            }
+          });
+        }
       } else {
         resolve(true);
       }


### PR DESCRIPTION
Prompt an "Are you sure?" dialog when user attempts to leave the customer and subscription page forms.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Allow users a chance to recover their form info before navigating away.

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
