### PR TITLE
feature: cpd-736 Add buffer time to subscriptions

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -433,8 +433,40 @@
       <div class="text-muted mb-3">
         <em>Target Count: {{ subscription.target_email_list.length }}</em>
       </div>
-      <!-- Email Sent Time -->
       <mat-label class="h6">Sending Strategy</mat-label>
+
+      <!-- Buffer Time -->
+      <mat-label class="h7">Buffer Time</mat-label>
+      <div class="mb-2">
+        <div class="text-muted">
+          Time added to create a buffer between the start date and the first
+          email being sent. (Must be between 30 minutes and 30 days)
+        </div>
+        <mat-form-field appearance="outline">
+          <mat-label>Time</mat-label>
+          <input
+            matInput
+            formControlName="bufferDisplayTime"
+            type="text"
+            trim="blur"
+          />
+          <mat-error
+            *ngIf="f.bufferDisplayTime.errors?.outOfRange"
+            class="invalid-feedback"
+          >
+            Must be between 30 minutes and 30 days
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Time Units</mat-label>
+          <mat-select formControlName="bufferTimeUnit">
+            <mat-option *ngFor="let time of timeRanges" [value]="time">
+              {{ time }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <!-- Email Sent Time -->
       <mat-label class="h7">Email Sent Time</mat-label>
       <div class="mb-2">
         <div class="text-muted">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -46,7 +46,6 @@ import { UserService } from 'src/app/services/user.service';
 import { UserModel } from 'src/app/models/user.model';
 import { TemplateModel } from 'src/app/models/template.model';
 import { SendingProfileModel } from 'src/app/models/sending-profile.model';
-import { NavigateAwayComponent } from 'src/app/components/dialogs/navigate-away/navigate-away.component';
 
 @Component({
   selector: 'subscription-config-tab',
@@ -242,31 +241,17 @@ export class SubscriptionConfigTab
   private isNavigationAllowed(): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       if (this.subscribeForm.dirty) {
-        if (this.pageMode == 'CREATE') {
-          this.dialogRefConfirm = this.dialog.open(NavigateAwayComponent);
-          this.dialogRefConfirm.afterClosed().subscribe((result) => {
-            if (result === 'save') {
-              this.save();
-              resolve(true);
-            } else if (result === 'discard') {
-              resolve(true);
-            } else {
-              resolve(false);
-            }
-          });
-        } else {
-          this.dialogRefConfirm = this.dialog.open(UnsavedComponent);
-          this.dialogRefConfirm.afterClosed().subscribe((result) => {
-            if (result === 'save') {
-              this.save();
-              resolve(true);
-            } else if (result === 'discard') {
-              resolve(true);
-            } else {
-              resolve(false);
-            }
-          });
-        }
+        this.dialogRefConfirm = this.dialog.open(UnsavedComponent);
+        this.dialogRefConfirm.afterClosed().subscribe((result) => {
+          if (result === 'save') {
+            this.save();
+            resolve(true);
+          } else if (result === 'discard') {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
       } else {
         resolve(true);
       }

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -191,8 +191,8 @@ export class SubscriptionConfigTab
           validators: [this.invalidCsv(), this.domainListValidator()],
           updateOn: 'blur',
         }),
-        bufferTime: new FormControl(86400),
-        bufferDisplayTime: new FormControl(86400),
+        bufferTime: new FormControl(21600),
+        bufferDisplayTime: new FormControl(21600),
         bufferTimeUnit: new FormControl('Minutes'),
         cycle_length_minutes: new FormControl(86400, {
           validators: [Validators.required],

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -70,6 +70,7 @@ export class SubscriptionConfigTab
   subscriptionPreviousTimeUnit = 'Minutes';
   reportPeriodPreviousTimeUnit = 'Minutes';
   cooldownPreviousTimeUnit = 'Minutes';
+  bufferPreviousTimeUnit = 'Minutes';
   templatesSelected = [];
   templatesAvailable = [];
   dailyRate = '';
@@ -190,6 +191,9 @@ export class SubscriptionConfigTab
           validators: [this.invalidCsv(), this.domainListValidator()],
           updateOn: 'blur',
         }),
+        bufferTime: new FormControl(86400),
+        bufferDisplayTime: new FormControl(86400),
+        bufferTimeUnit: new FormControl('Minutes'),
         cycle_length_minutes: new FormControl(86400, {
           validators: [Validators.required],
         }),
@@ -369,6 +373,28 @@ export class SubscriptionConfigTab
       })
     );
 
+    // On changes to buffer time
+    this.angular_subs.push(
+      this.f.bufferDisplayTime.valueChanges.subscribe((val) => {
+        this.subscription.buffer_time_minutes = this.onDisplayTimeChanges(
+          this.f.bufferTime,
+          this.f.bufferDisplayTime,
+          this.bufferPreviousTimeUnit
+        );
+      })
+    );
+
+    // On changes to buffer time unit
+    this.angular_subs.push(
+      this.f.bufferTimeUnit.valueChanges.subscribe((val) => {
+        this.bufferPreviousTimeUnit = this.onTimeUnitChanges(
+          this.f.bufferDisplayTime,
+          this.bufferPreviousTimeUnit,
+          val
+        );
+      })
+    );
+
     // On changes to cooldown time unit
     this.angular_subs.push(
       this.f.cooldownTimeUnit.valueChanges.subscribe((val) => {
@@ -425,6 +451,9 @@ export class SubscriptionConfigTab
     }
     if (this.f.reportDisplayTime.value > 1440) {
       this.f.reportTimeUnit.setValue('Days');
+    }
+    if (this.f.bufferDisplayTime.value > 1440) {
+      this.f.bufferTimeUnit.setValue('Days');
     }
   }
 
@@ -575,6 +604,10 @@ export class SubscriptionConfigTab
       emitEvent: false,
     });
     this.f.report_frequency_minutes.setValue(s.report_frequency_minutes, {
+      emitEvent: false,
+    });
+    this.f.bufferTime.setValue(s.buffer_time_minutes, { emitEvent: false });
+    this.f.bufferDisplayTime.setValue(s.buffer_time_minutes, {
       emitEvent: false,
     });
     this.f.subDisplayTime.setValue(s.cycle_length_minutes, {
@@ -925,9 +958,11 @@ export class SubscriptionConfigTab
     const cycleLength: number = +this.f.cycle_length_minutes.value;
     const cooldownLength: number = +this.f.cooldown_minutes.value;
     const reportLength: number = +this.f.report_frequency_minutes.value;
+    const bufferTimeLength: number = +this.f.bufferTime.value;
     sub.cycle_length_minutes = cycleLength;
     sub.report_frequency_minutes = reportLength;
     sub.cooldown_minutes = cooldownLength;
+    sub.buffer_time_minutes = bufferTimeLength;
     this.setTemplatesSelected();
     sub.templates_selected = this.subscription.templates_selected;
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -1035,10 +1035,12 @@ export class SubscriptionConfigTab
    */
   enableDisableFields() {
     const status = this.subscription?.status?.toLowerCase();
-    if (status === 'in progress') {
+    if (status === 'running') {
       this.f.startDate.disable();
       this.f.sendingProfile.disable();
       this.f.targetDomain.disable();
+      this.f.bufferDisplayTime.disable();
+      this.f.bufferTimeUnit.disable();
       //this.f.csvText.disable();
     } else {
       this.f.startDate.enable();

--- a/src/AdminUI/src/app/models/subscription.model.ts
+++ b/src/AdminUI/src/app/models/subscription.model.ts
@@ -54,6 +54,7 @@ export class SubscriptionModel {
   templates_selected: string[];
   active: boolean;
   continuous_subscription: boolean;
+  buffer_time_minutes: number;
   cycle_length_minutes: number;
   cooldown_minutes: number;
   report_frequency_minutes: number;

--- a/src/AdminUI/src/app/services/subscription.service.ts
+++ b/src/AdminUI/src/app/services/subscription.service.ts
@@ -106,6 +106,7 @@ export class SubscriptionService {
       target_domain: subscription.target_domain,
       continuous_subscription: subscription.continuous_subscription,
       templates_selected: subscription.templates_selected,
+      buffer_time_minutes: subscription.buffer_time_minutes,
       cycle_length_minutes: subscription.cycle_length_minutes,
       cooldown_minutes: subscription.cooldown_minutes,
       report_frequency_minutes: subscription.report_frequency_minutes,


### PR DESCRIPTION
Add buffer time field to subscriptions. 

## 🗣 Description ##
Disable the ability to modify the buffer time when subscriptions are running
Allow a buffer between the start date and the send_by_date

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
