### PR TITLE
feature: Start Time field improvements

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -101,8 +101,9 @@
 
       <mat-label class="h6">Start Date</mat-label>
       <p>Appendix A Date: {{ customer.appendix_a_date | date: "MM/dd/yy" }}</p>
-      <div class="text-muted mb-2">Based on your local timezone.</div>
-      <div class="text-muted">Use 12h or 24h time format.</div>
+      <div class="text-muted mb-2">
+        Based on your local timezone. Use 12h or 24h time format.
+      </div>
       <div class="mb-4">
         <mat-form-field appearance="outline">
           <input

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -101,7 +101,8 @@
 
       <mat-label class="h6">Start Date</mat-label>
       <p>Appendix A Date: {{ customer.appendix_a_date | date: "MM/dd/yy" }}</p>
-      <div class="text-muted">Based on your local timezone.</div>
+      <div class="text-muted mb-2">Based on your local timezone.</div>
+      <div class="text-muted">Use 12h or 24h time format.</div>
       <div class="mb-4">
         <mat-form-field appearance="outline">
           <input
@@ -133,15 +134,9 @@
             matInput
             formControlName="startTime"
             format="24"
-            [ngxMatTimepicker]="timePicker"
-            placeholder="HH:MM"
-            readonly
+            placeholder="HH:MM or HH:MM AM/PM"
           />
-          <mat-icon matSuffix (click)="timePicker.open()">
-            watch_later
-          </mat-icon>
         </mat-form-field>
-        <ngx-mat-timepicker #timePicker></ngx-mat-timepicker>
         <mat-error *ngIf="startBeforeAppendixDate" class="invalid-feedback">
           Start Date can not be before the Appendix A Date
         </mat-error>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.scss
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.scss
@@ -11,6 +11,7 @@
 .startButton {
   align-self: right;
 }
+
 .active_subscription {
   margin-top: 1em;
 }
@@ -22,6 +23,7 @@
   margin-top: 1em;
   margin-bottom: 4em;
 }
+
 .template-selection-level-container {
   border: 1px solid rgba(0, 0, 0, 0.25);
   border-radius: 5px;
@@ -31,24 +33,30 @@
   margin: 0.5em;
   // max-width: 800px;
 }
+
 .template-selection-level-container > table > tbody > tr:hover {
   background-color: #d6e9f2;
 }
+
 .tslc-title {
   margin-top: -1.5em;
   position: absolute;
 }
+
 .template-selected-list {
   list-style: none;
   padding: 0.5em;
   width: 100%;
 }
+
 .template-selction-row {
   min-width: 100%;
 }
+
 .template-selction-row:hover {
   background: rgba(0, 0, 0, 0.15);
 }
+
 .change-template-btn {
   display: inline-block;
   position: absolute;
@@ -58,6 +66,7 @@
   width: 11em;
   margin-right: 0 !important;
 }
+
 .rotate-header-btn {
   margin-left: 8px;
   display: inline-block;

--- a/src/AdminUI/src/styles.scss
+++ b/src/AdminUI/src/styles.scss
@@ -313,6 +313,7 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
   .mat-sort-header-stem {
     color: white;
   }
+
   .mat-sort-header-indicator {
     color: white;
   }
@@ -336,6 +337,7 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
 .material-icons {
   font-size: 24px;
   font-family: "Material Icons", "Material Icons";
+
   .mat-badge-content {
     font-family: "Roboto";
   }
@@ -361,6 +363,7 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
 .material-icons {
   font-size: 24px;
   font-family: "Material Icons", "Material Icons";
+
   .mat-badge-content {
     font-family: "Roboto";
   }
@@ -375,6 +378,7 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !important;
 }
+
 .mat-button.mat-primary:hover,
 .mat-stroked-button.mat-success:hover {
   background-color: #ffffff !important;
@@ -418,11 +422,13 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
 .material-icons {
   font-size: 24px;
   font-family: "Material Icons", "Material Icons";
+
   .mat-badge-content {
     font-family: "Roboto";
     color: "#fff";
   }
 }
+
 :focus {
   outline: none !important;
 }
@@ -477,6 +483,14 @@ table.table-1 td {
   margin-right: 10px;
 }
 
+.mat-form-field-disabled {
+  background-color: white;
+}
+
+.disabled-color {
+  background-color: white;
+}
+
 .table-btn-icon {
   min-width: 0 !important;
   padding-left: 4px !important;
@@ -501,6 +515,7 @@ table.table-1 td {
 .needs-work {
   // background-color: #ffff00;
 }
+
 .randomize-button {
   background-color: #29ab87;
   color: white;


### PR DESCRIPTION
Improve the start time field in subscriptions. Remove unnecessary clock pop up and allow for inputting time in 24h or 12h format

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
