### PR TITLE
Feature CPD-989 & CPD-990 & CPD-1016: Cycle active indicator and button css

### DIFF
--- a/src/AdminUI/src/app/components/overview/failed-emails-tab/failed-emails-tab.component.html
+++ b/src/AdminUI/src/app/components/overview/failed-emails-tab/failed-emails-tab.component.html
@@ -7,22 +7,29 @@
   </p>
   <div class="flex-container">
     <!-- SEARCH BAR -->
-    <mat-form-field class="d-flex flex-column w-100" appearance="outline">
-      <mat-label>Search</mat-label>
-      <input
-        [(ngModel)]="search_input"
-        (keyup)="filterEmails($event.target.value)"
-        matInput
-        placeholder="Search"
-      />
-      <mat-icon matSuffix>search</mat-icon>
-    </mat-form-field>
-    <button mat-raised-button color="primary" (click)="pageRefresh()">
+    <div class="d-flex flex-column w-100">
+      <mat-form-field class="d-flex flex-column w-80" appearance="outline">
+        <mat-label>Search</mat-label>
+        <input
+          [(ngModel)]="search_input"
+          (keyup)="filterEmails($event.target.value)"
+          matInput
+          placeholder="Search"
+        />
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
+    </div>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="pageRefresh()"
+      style="width: 120px; height: 50px"
+    >
       Refresh
       <mat-icon class="table-btn-icon-size">autorenew</mat-icon>
     </button>
     <button
-      style="width: 1em"
+      style="width: 65px; height: 50px"
       mat-raised-button
       color="primary"
       (click)="downloadFailedEmailsJSON()"
@@ -34,6 +41,7 @@
       mat-raised-button
       color="accent"
       [matMenuTriggerFor]="menu"
+      style="width: 120px; height: 50px"
     >
       Actions<mat-icon>arrow_drop_down</mat-icon>
     </button>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
@@ -62,6 +62,10 @@
         <td>{{ selectedCycle?._id }}</td>
       </tr>
       <tr>
+        <td>Active</td>
+        <td>{{ selectedCycle?.active }}</td>
+      </tr>
+      <tr>
         <td>Cisa-Phish</td>
         <td>{{ selectedCycle?.phish_header }}</td>
       </tr>

--- a/src/AdminUI/src/styles.scss
+++ b/src/AdminUI/src/styles.scss
@@ -388,7 +388,7 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
 .mat-flat-button.mat-primary,
 .mat-fab.mat-primary,
 .mat-mini-fab.mat-primary {
-  color: #f0fff3;
+  color: #ffffff;
   background-color: #29ab87;
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira Tickets: https://cset.atlassian.net/browse/CPD-989
https://cset.atlassian.net/browse/CPD-990
https://cset.atlassian.net/browse/CPD-1016

Added an indicator for whether the selected cycle is active on the subscription > cycles tab.
Changed the sizing and coloration of some buttons for general consistency.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

General front-end stylistic clean-up. Also, knowing which cycle is currently active at a glance is incredibly helpful. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

