### PR TITLE
fix: user confirm button

### DIFF
--- a/src/AdminUI/src/app/components/users/users.component.html
+++ b/src/AdminUI/src/app/components/users/users.component.html
@@ -42,9 +42,13 @@
       >User Status</mat-header-cell
     >
     <mat-cell *matCellDef="let row">
-      <div *ngIf="row.status == 'CONFIRMED'">{{ row.status }}</div>
+      <div *ngIf="row.status == 'CONFIRMED'">confirmed</div>
+      <div *ngIf="row.status == 'RESET_REQUIRED'">reset required</div>
+      <div *ngIf="row.status == 'FORCE_CHANGE_PASSWORD'">
+        change password required
+      </div>
       <button
-        *ngIf="row.status != 'CONFIRMED'"
+        *ngIf="row.status == 'UNCONFIRMED'"
         mat-raised-button
         color="accent"
         (click)="confirmUser(row.username)"


### PR DESCRIPTION
Fixed an issue where confirm user button shows even for users that are confirmed but need a password reset.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
