### PR TITLE
Feature CPD-1035: Buffer time updates

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -607,6 +607,11 @@
             All emails will be sent by {{ sendBy | date: "long" }} and the cycle
             will be completed on {{ endDate | date: "long" }}.
           </p>
+          <p>
+            If the subscription is chosen to be continuous, the buffer period
+            will end and a new cycle will start on
+            {{ nextCycleDate | date: "long" }}.
+          </p>
         </div>
       </div>
       <!-- Status Report Frequency -->
@@ -651,6 +656,17 @@
           >Continuous Subscription Cycles</mat-checkbox
         >
       </div>
+
+      <div *ngIf="isContinuous()">
+        <mat-label class="h6" style="margin-top: 2rem"
+          >Next Cycle Date</mat-label
+        >
+        <p>
+          For your information, the next cycle is scheduled to automatically
+          start on {{ nextCycleDate | date: "long" }}
+        </p>
+      </div>
+
       <div class="d-flex flex-row-reverse justify-content-between">
         <div class="d-flex flex-row">
           <!-- DROP DOWN MENU BUTTON -->

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -476,14 +476,61 @@
       <div class="text-muted mb-3">
         <em>Target Count: {{ subscription.target_email_list.length }}</em>
       </div>
+      <div class="text-muted">
+        *Note while a subscription is actively running, changes to the email
+        list will not take effect until the next 90 day cycle.
+      </div>
+
+      <!-- Status Report Frequency -->
+      <mat-label class="h6" style="margin-top: 25px"
+        >Status Report Frequency</mat-label
+      >
+      <div class="mb-4">
+        <div class="text-muted">
+          The frequency at which the status report is sent out to the customer
+          and CISA contact for this subscription. (Must be between 15 minutes
+          and 360 days)
+        </div>
+        <mat-form-field appearance="outline">
+          <mat-label>Time</mat-label>
+          <input
+            matInput
+            formControlName="reportDisplayTime"
+            type="text"
+            trim="blur"
+          />
+          <mat-error
+            *ngIf="f.reportDisplayTime.errors?.outOfRange"
+            class="invalid-feedback"
+          >
+            Must be between 15 minutes and 360 days
+          </mat-error>
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Time Units</mat-label>
+          <mat-select formControlName="reportTimeUnit">
+            <mat-option *ngFor="let time of timeRanges" [value]="time">
+              {{ time }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+
       <mat-label class="h6">Sending Strategy</mat-label>
       <p>
         Please note, for continuous subscriptions that are currently in
         progress, any modifications to the Sending Strategy fields below will
         reflect on the next cycle.
       </p>
+
+      <div class="continuous-subscription-checkbox">
+        <mat-checkbox formControlName="continuousSubscription"
+          >Continuous Subscription Cycles</mat-checkbox
+        >
+      </div>
+
       <!-- Email Sent Time -->
-      <mat-label class="h7">Email Sent Time</mat-label>
+      <mat-label class="h7" style="margin-top: 10px">Email Sent Time</mat-label>
       <div class="mb-2">
         <div class="text-muted">
           The time that all emails will be sent within. (Must be between 15
@@ -572,14 +619,15 @@
           </mat-select>
         </mat-form-field>
       </div>
+
       <!-- Buffer Time -->
-      <mat-label class="h7">Buffer Time</mat-label>
+      <mat-label class="h7" *ngIf="isContinuous()">Buffer Time</mat-label>
       <div class="mb-2">
         <div class="text-muted">
           Time added to create a buffer at the end date of each cycle. (Must be
           between 15 minutes and 30 days)
         </div>
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" *ngIf="isContinuous()">
           <mat-label>Time</mat-label>
           <input
             matInput
@@ -594,7 +642,7 @@
             Must be between 15 minutes and 30 days
           </mat-error>
         </mat-form-field>
-        <mat-form-field appearance="outline">
+        <mat-form-field appearance="outline" *ngIf="isContinuous()">
           <mat-label>Time Units</mat-label>
           <mat-select formControlName="bufferTimeUnit">
             <mat-option *ngFor="let time of timeRanges" [value]="time">
@@ -607,54 +655,7 @@
             All emails will be sent by {{ sendBy | date: "long" }} and the cycle
             will be completed on {{ endDate | date: "long" }}.
           </p>
-          <p>
-            If the subscription is chosen to be continuous, the buffer period
-            will end and a new cycle will start on
-            {{ nextCycleDate | date: "long" }}.
-          </p>
         </div>
-      </div>
-      <!-- Status Report Frequency -->
-      <mat-label class="h6">Status Report Frequency</mat-label>
-      <div class="mb-4">
-        <div class="text-muted">
-          The frequency at which the status report is sent out to the customer
-          and CISA contact for this subscription. (Must be between 15 minutes
-          and 360 days)
-        </div>
-        <mat-form-field appearance="outline">
-          <mat-label>Time</mat-label>
-          <input
-            matInput
-            formControlName="reportDisplayTime"
-            type="text"
-            trim="blur"
-          />
-          <mat-error
-            *ngIf="f.reportDisplayTime.errors?.outOfRange"
-            class="invalid-feedback"
-          >
-            Must be between 15 minutes and 360 days
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field appearance="outline">
-          <mat-label>Time Units</mat-label>
-          <mat-select formControlName="reportTimeUnit">
-            <mat-option *ngFor="let time of timeRanges" [value]="time">
-              {{ time }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <div class="text-muted">
-        *Note while a subscription is actively running, changes to the email
-        list will not take effect until the next 90 day cycle.
-      </div>
-
-      <div class="continuous-subscription-checkbox">
-        <mat-checkbox formControlName="continuousSubscription"
-          >Continuous Subscription Cycles</mat-checkbox
-        >
       </div>
 
       <div *ngIf="isContinuous()">

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -97,6 +97,7 @@ export class SubscriptionConfigTab
   startAt = new Date();
   sendBy = new Date();
   endDate = new Date();
+  nextCycleDate = new Date();
   appendixADate = new Date();
   startBeforeAppendixDate = false;
 
@@ -539,11 +540,19 @@ export class SubscriptionConfigTab
     }
     const cycleLength: number = +this.f.cycle_length_minutes.value;
     const cooldownLength: number = +this.f.cooldown_minutes.value;
+    const bufferLength: number = +this.f.bufferTime.value;
     this.sendBy = new Date(start);
     this.sendBy.setMinutes(this.sendBy.getMinutes() + cycleLength);
     this.endDate = new Date(start);
     this.endDate.setMinutes(
       this.endDate.getMinutes() + cycleLength + cooldownLength
+    );
+    this.nextCycleDate = new Date(start);
+    this.nextCycleDate.setMinutes(
+      this.nextCycleDate.getMinutes() +
+        cycleLength +
+        cooldownLength +
+        bufferLength
     );
   }
 
@@ -833,6 +842,15 @@ export class SubscriptionConfigTab
   targetsChanged(e: any) {
     this.csvText = e.target.value;
     this.f.csvText.setValue(e.target.value);
+  }
+
+  isContinuous(): boolean {
+    if (this.subscription.continuous_subscription) {
+      console.log(this.subscription.continuous_subscription);
+      return true;
+    }
+    console.log(this.subscription.continuous_subscription);
+    return false;
   }
 
   /**


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Jira Ticket: https://cset.atlassian.net/browse/CPD-1035

Backend changes: https://github.com/cisagov/con-pca-api/pull/836

Added in next cycle start date message factoring in buffer time in subscription config tab

Do not display the buffer time user input fields unless the subscription is continuous, since buffer time does not matter for non-continuous cycles.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Make it clear to users when a cycle will restart, accounting for buffer time.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested Locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

