### PR TITLE
Maintenance CPD-1030:  Login page maintenance mode message

### DIFF
--- a/src/AdminUI/src/app/components/login/login.component.html
+++ b/src/AdminUI/src/app/components/login/login.component.html
@@ -10,54 +10,6 @@
           accessible again soon!
         </p>
       </div>
-      <p>
-        <mat-form-field appearance="outline">
-          <input
-            type="text"
-            matInput
-            placeholder="Username (Developer)"
-            [formControl]="username"
-            autocomplete="off"
-            [errorStateMatcher]="matcherusername"
-          />
-          <mat-icon matPrefix style="margin-right: 10px">face</mat-icon>
-          <mat-error *ngIf="username.hasError('required')">
-            Username is <strong>required</strong>
-          </mat-error>
-        </mat-form-field>
-      </p>
-
-      <p>
-        <mat-form-field appearance="outline">
-          <input
-            type="password"
-            matInput
-            placeholder="Password (Developer)"
-            [formControl]="password"
-            autocomplete="off"
-            [errorStateMatcher]="matcherpassword"
-          />
-          <mat-icon matPrefix style="margin-right: 10px">lock</mat-icon>
-          <mat-error *ngIf="password.hasError('required')">
-            Password is <strong>required</strong>
-          </mat-error>
-        </mat-form-field>
-      </p>
-
-      <p *ngIf="error" class="error">
-        {{ error }}
-      </p>
-
-      <button
-        class="button-right"
-        type="submit"
-        [disabled]="password.hasError('required')"
-        mat-raised-button
-        color="accent"
-        (click)="submit()"
-      >
-        Login
-      </button>
       <!--
       <div style="width: 350px">
         <p>

--- a/src/AdminUI/src/app/components/login/login.component.html
+++ b/src/AdminUI/src/app/components/login/login.component.html
@@ -6,6 +6,61 @@
     <form autocomplete="off">
       <div style="width: 350px">
         <p>
+          Con-PCA is currently undergoing maintenance. The site will be
+          accessible again soon!
+        </p>
+      </div>
+      <p>
+        <mat-form-field appearance="outline">
+          <input
+            type="text"
+            matInput
+            placeholder="Username (Developer)"
+            [formControl]="username"
+            autocomplete="off"
+            [errorStateMatcher]="matcherusername"
+          />
+          <mat-icon matPrefix style="margin-right: 10px">face</mat-icon>
+          <mat-error *ngIf="username.hasError('required')">
+            Username is <strong>required</strong>
+          </mat-error>
+        </mat-form-field>
+      </p>
+
+      <p>
+        <mat-form-field appearance="outline">
+          <input
+            type="password"
+            matInput
+            placeholder="Password (Developer)"
+            [formControl]="password"
+            autocomplete="off"
+            [errorStateMatcher]="matcherpassword"
+          />
+          <mat-icon matPrefix style="margin-right: 10px">lock</mat-icon>
+          <mat-error *ngIf="password.hasError('required')">
+            Password is <strong>required</strong>
+          </mat-error>
+        </mat-form-field>
+      </p>
+
+      <p *ngIf="error" class="error">
+        {{ error }}
+      </p>
+
+      <button
+        class="button-right"
+        type="submit"
+        [disabled]="password.hasError('required')"
+        mat-raised-button
+        color="accent"
+        (click)="submit()"
+      >
+        Login
+      </button>
+      <!--
+      <div style="width: 350px">
+        <p>
           Please enter your Con-PCA login info below to log in. If you have
           problems logging in, please contact the Con-PCA Admin.
         </p>
@@ -77,6 +132,7 @@
           Register User
         </button>
       </div>
+      -->
     </form>
   </mat-card-content>
 </mat-card>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Backend changes: https://github.com/cisagov/con-pca-api/pull/841

Jira ticket: https://cset.atlassian.net/browse/CPD-1030

Temporary code to ensure no admin-user-related database activity while database updates are being made to production.

The login page does not actually stop authorized users from authenticating, because access to the webpage is needed as part of the upgrade, however it should be clear to clients that Con-PCA is currently in maintenance mode and that only developers should be logging in.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We don't want to lose data during the upgrade. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

