### PR TITLE
Fix CPD-1113: defaults for all variables in subscription info export

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
@@ -23,6 +23,7 @@ import {
   ValidatorFn,
 } from '@angular/forms';
 import { ConfirmComponent } from 'src/app/components/dialogs/confirm/confirm.component';
+import { NONE_TYPE } from '@angular/compiler';
 
 @Component({
   selector: 'app-subscription-cycles-tab',
@@ -238,11 +239,40 @@ export class SubscriptionStatsTab implements OnInit {
       } else {
         statusReportDays = 'None';
       }
-      cycleReportDay = `${new Date(
-        this.subscription.tasks.find(
-          (t) => t.task_type === 'cycle_report',
-        ).scheduled_date,
-      ).toDateString()}`;
+      const cycleReportTask = this.subscription.tasks.find(
+        (t) => t.task_type === 'cycle_report',
+      );
+      if (cycleReportTask) {
+        cycleReportDay = `${new Date(
+          cycleReportTask.scheduled_date,
+        ).toDateString()}`;
+      } else {
+        cycleReportDay = 'None';
+      }
+    }
+    if (!this.subscription.start_date) {
+      this.subscription.start_date = null;
+    }
+    if (!this.subscription.primary_contact.email) {
+      this.subscription.primary_contact.email = 'None';
+    }
+    if (!this.subscription.target_email_list) {
+      this.subscription.target_email_list = [];
+    }
+    if (!this.selectedCycle.send_by_date) {
+      this.selectedCycle.send_by_date = null;
+    }
+    if (!this.selectedCycle.end_date) {
+      this.selectedCycle.end_date = null;
+    }
+    if (!this.hourlyRate) {
+      this.hourlyRate = 0;
+    }
+    if (!this.dailyRate) {
+      this.dailyRate = 0;
+    }
+    if (!nextCyclesLaunchDay) {
+      nextCyclesLaunchDay = null;
     }
 
     const data = {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

defaults for all variables in subscription info export

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Avoid errors

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Testing locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.

