### PR TITLE
Feature: Always display next templates

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.html
@@ -195,7 +195,7 @@
                 <div *ngFor="let i of currentTemplateSubjects">{{ i }}</div>
               </td>
             </tr>
-            <tr *ngIf="isContinuous()">
+            <tr *ngIf="nextTemplatesExist()">
               <td>Next Cycle Templates</td>
               <td class="text-right" style="color: grey; cursor: default">
                 <div *ngFor="let i of nextTemplateSubjects">{{ i }}</div>

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -1637,7 +1637,10 @@ export class SubscriptionConfigTab
   }
 
   nextTemplatesExist() {
-    if (this.subscription.hasOwnProperty('next_templates')) {
+    if (
+      this.subscription.hasOwnProperty('next_templates') &&
+      this.subscription.next_templates.length > 0
+    ) {
       return true;
     } else {
       return false;

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-config-tab/subscription-config-tab.component.ts
@@ -1635,4 +1635,12 @@ export class SubscriptionConfigTab
       this.hideReportingPassword = false;
     });
   }
+
+  nextTemplatesExist() {
+    if (this.subscription.hasOwnProperty('next_templates')) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Testing on next templates should be possible before changing a subscription to continuous, therefore next templates should always be displayed regardless of whether the subscription is continuous or not. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.
