### PR TITLE
Fix: Template validation retire workaround

### DIFF
--- a/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
+++ b/src/AdminUI/src/app/components/template-manager/template-manager.component.ts
@@ -593,24 +593,44 @@ export class TemplateManagerComponent
   }
 
   openRetireTemplateDialog() {
-    const templateToRetire = this.getTemplateFromForm(
-      this.currentTemplateFormGroup,
-    );
-    this.dialogRefRetire = this.dialog.open(RetireTemplateDialogComponent, {
-      disableClose: false,
-      data: templateToRetire,
-    });
-    this.dialogRefRetire.afterClosed().subscribe((result) => {
-      if (result.retired) {
-        this.retired = result.retired;
-        this.retiredReason = result.description;
-        this.setCanDelete();
-      } else if (result.error) {
-        this.alertsService.alert(
-          `Error retiring template. ${result.error.error}`,
-        );
+    this.currentTemplateFormGroup.markAllAsTouched();
+    if (this.currentTemplateFormGroup.valid) {
+      const templateToRetire = this.getTemplateFromForm(
+        this.currentTemplateFormGroup,
+      );
+      this.dialogRefRetire = this.dialog.open(RetireTemplateDialogComponent, {
+        disableClose: false,
+        data: templateToRetire,
+      });
+      this.dialogRefRetire.afterClosed().subscribe((result) => {
+        if (result.retired) {
+          this.retired = result.retired;
+          this.retiredReason = result.description;
+          this.setCanDelete();
+        } else if (result.error) {
+          this.alertsService.alert(
+            `Error retiring template. ${result.error.error}`,
+          );
+        }
+      });
+    } else {
+      //non valid form, collect nonvalid fields and display to user
+      const invalid = [];
+      const controls = this.currentTemplateFormGroup.controls;
+      for (const name in controls) {
+        if (controls[name].invalid) {
+          let nameIng = 'Template ' + name.replace(/template/g, '');
+          invalid.push(nameIng);
+        }
       }
-    });
+      this.dialog.open(AlertComponent, {
+        data: {
+          title: 'Missing Required Information',
+          messageText: '',
+          invalidData: invalid,
+        },
+      });
+    }
   }
 
   openRestoreTemplateDialog() {
@@ -908,36 +928,56 @@ export class TemplateManagerComponent
   }
 
   async duplicateTemplate() {
-    const dialogRef = this.dialog.open(ConfirmComponent, {
-      disableClose: false,
-    });
-    dialogRef.componentInstance.confirmMessage = `Are you sure you want to create a duplicate template?`;
-    dialogRef.componentInstance.title = 'Confirm';
+    this.currentTemplateFormGroup.markAllAsTouched();
+    if (this.currentTemplateFormGroup.valid) {
+      const dialogRef = this.dialog.open(ConfirmComponent, {
+        disableClose: false,
+      });
+      dialogRef.componentInstance.confirmMessage = `Are you sure you want to create a duplicate template?`;
+      dialogRef.componentInstance.title = 'Confirm';
 
-    const dialogResp = await dialogRef.afterClosed().toPromise();
-    if (dialogResp) {
-      try {
-        await this.templateManagerSvc
-          .duplicateTemplate(this.templateId)
-          .toPromise();
-        this.dialog.open(AlertComponent, {
-          data: {
-            title: '',
-            messageText: `'${this.templateName} COPY' template has been duplicated.`,
-          },
-        });
+      const dialogResp = await dialogRef.afterClosed().toPromise();
+      if (dialogResp) {
+        try {
+          await this.templateManagerSvc
+            .duplicateTemplate(this.templateId)
+            .toPromise();
+          this.dialog.open(AlertComponent, {
+            data: {
+              title: '',
+              messageText: `'${this.templateName} COPY' template has been duplicated.`,
+            },
+          });
 
-        this.router.navigate(['/templates']);
-      } catch (error) {
-        console.log(error);
-        this.dialog.open(AlertComponent, {
-          // Parse error here
-          data: {
-            title: `Duplicate Template Error - ${error.statusText}`,
-            messageText: JSON.stringify(error.error),
-          },
-        });
+          this.router.navigate(['/templates']);
+        } catch (error) {
+          console.log(error);
+          this.dialog.open(AlertComponent, {
+            // Parse error here
+            data: {
+              title: `Duplicate Template Error - ${error.statusText}`,
+              messageText: JSON.stringify(error.error),
+            },
+          });
+        }
       }
+    } else {
+      //non valid form, collect nonvalid fields and display to user
+      const invalid = [];
+      const controls = this.currentTemplateFormGroup.controls;
+      for (const name in controls) {
+        if (controls[name].invalid) {
+          let nameIng = 'Template ' + name.replace(/template/g, '');
+          invalid.push(nameIng);
+        }
+      }
+      this.dialog.open(AlertComponent, {
+        data: {
+          title: 'Missing Required Information',
+          messageText: '',
+          invalidData: invalid,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Added extra safeties to prevent incomplete templates from being saved.


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Templates should not be allowed to be saved when missing required fields. Testing discovered that the validation could be bypassed by archiving and unarchiving a template. Presumably this workaround could be done with duplication also.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.
