### PR TITLE
Remove disabled cycle buttons

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
@@ -101,12 +101,6 @@
           <th>{{ t | titlecase }}</th>
           <td>
             <button
-              [disabled]="
-                subscription.status == 'created' ||
-                (selectedCycle.active && t == 'cycle')
-                  ? true
-                  : null
-              "
               mat-raised-button
               color="primary"
               (click)="downloadReport(t); $event.preventDefault()"
@@ -116,12 +110,6 @@
           </td>
           <td>
             <button
-              [disabled]="
-                subscription.status == 'created' ||
-                (selectedCycle.active && t == 'cycle')
-                  ? true
-                  : null
-              "
               mat-raised-button
               color="accent"
               (click)="sendReport(t); $event.preventDefault()"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Cycle report buttons should not be disabled while the cycle is active, just during the active sending period

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tested locally

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.


