### PR TITLE
Disable Report Button when Active or Cooldown

### DIFF
--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
@@ -99,8 +99,9 @@
       <tbody>
         <tr *ngFor="let t of ['status', 'cycle']">
           <th>{{ t | titlecase }}</th>
-          <td>
+          <td matTooltip="Must wait for the cycle to be comlpete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
             <button
+              [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button
               color="primary"
               (click)="downloadReport(t); $event.preventDefault()"
@@ -108,8 +109,9 @@
               <mat-icon>cloud_download</mat-icon>
             </button>
           </td>
-          <td>
+          <td matTooltip="Must wait for the cycle to be comlpete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
             <button
+              [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button
               color="accent"
               (click)="sendReport(t); $event.preventDefault()"

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
@@ -99,7 +99,7 @@
       <tbody>
         <tr *ngFor="let t of ['status', 'cycle']">
           <th>{{ t | titlecase }}</th>
-          <td matTooltip="Must wait for the cycle to be comlpete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
+          <td matTooltip="Must wait for the cycle to be complete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
             <button
               [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button
@@ -109,7 +109,7 @@
               <mat-icon>cloud_download</mat-icon>
             </button>
           </td>
-          <td matTooltip="Must wait for the cycle to be comlpete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
+          <td matTooltip="Must wait for the cycle to be complete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
             <button
               [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.html
@@ -99,7 +99,10 @@
       <tbody>
         <tr *ngFor="let t of ['status', 'cycle']">
           <th>{{ t | titlecase }}</th>
-          <td matTooltip="Must wait for the cycle to be complete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
+          <td
+            matTooltip="Must wait for the cycle to be complete"
+            [matTooltipDisabled]="allowCycleDownload || t != 'cycle'"
+          >
             <button
               [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button
@@ -109,7 +112,10 @@
               <mat-icon>cloud_download</mat-icon>
             </button>
           </td>
-          <td matTooltip="Must wait for the cycle to be complete" [matTooltipDisabled]="allowCycleDownload || t != 'cycle'">
+          <td
+            matTooltip="Must wait for the cycle to be complete"
+            [matTooltipDisabled]="allowCycleDownload || t != 'cycle'"
+          >
             <button
               [disabled]="!allowCycleDownload && t == 'cycle'"
               mat-raised-button

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
@@ -24,6 +24,7 @@ import {
 } from '@angular/forms';
 import { ConfirmComponent } from 'src/app/components/dialogs/confirm/confirm.component';
 import { NONE_TYPE } from '@angular/compiler';
+import { now } from 'moment';
 
 @Component({
   selector: 'app-subscription-cycles-tab',
@@ -45,6 +46,8 @@ export class SubscriptionStatsTab implements OnInit {
   downloadingCycle = false;
   downloadingSubscription = false;
   downloadingText = 'Downloading Cycle Data';
+  
+  allowCycleDownload = false;
 
   generating = false;
   generatingText = '';
@@ -94,6 +97,7 @@ export class SubscriptionStatsTab implements OnInit {
         let selectedCycleIndex = 0;
         this.selectedCycle = this.subscription.cycles[selectedCycleIndex];
         this.subscriptionSvc.setCycleBehaviorSubject(this.selectedCycle);
+        this.setDisplayReportStatus();
         this.reportedStatsForm.controls.reportedItems.setValidators([
           this.reportListValidator(),
         ]);
@@ -116,11 +120,29 @@ export class SubscriptionStatsTab implements OnInit {
   cycleChange(event) {
     this.subscriptionSvc.setCycleBehaviorSubject(event.value);
     this.convertReportsToCSV();
+    this.setDisplayReportStatus();
   }
 
   showNonHuman(event: MatSlideToggleChange) {
     this.selectedCycle.nonhuman = event.checked;
     this.subscriptionSvc.setCycleBehaviorSubject(this.selectedCycle);
+  }
+
+  setDisplayReportStatus(){
+    console.log("TEST")
+    console.log(this.selectedCycle)
+    console.log(this.subscription)
+    let now = new Date()
+    let endDate = new Date(this.selectedCycle.end_date)
+    if(now.getTime() > endDate.getTime()){
+      this.allowCycleDownload = true;
+      console.log(this.allowCycleDownload)
+    } else {
+      this.allowCycleDownload = false
+      console.log(now)
+      console.log(endDate)
+    }
+    console.log(this.allowCycleDownload)
   }
 
   buildSubscriptionTimeline(s: SubscriptionModel) {

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
@@ -46,7 +46,7 @@ export class SubscriptionStatsTab implements OnInit {
   downloadingCycle = false;
   downloadingSubscription = false;
   downloadingText = 'Downloading Cycle Data';
-  
+
   allowCycleDownload = false;
 
   generating = false;
@@ -128,13 +128,13 @@ export class SubscriptionStatsTab implements OnInit {
     this.subscriptionSvc.setCycleBehaviorSubject(this.selectedCycle);
   }
 
-  setDisplayReportStatus(){
-    let now = new Date()
-    let endDate = new Date(this.selectedCycle.end_date)
-    if(now.getTime() > endDate.getTime()){
+  setDisplayReportStatus() {
+    let now = new Date();
+    let endDate = new Date(this.selectedCycle.end_date);
+    if (now.getTime() > endDate.getTime()) {
       this.allowCycleDownload = true;
     } else {
-      this.allowCycleDownload = false
+      this.allowCycleDownload = false;
     }
   }
 

--- a/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
+++ b/src/AdminUI/src/app/components/subscriptions/manage-subscription/subscription-cycles-tab/subscription-cycles-tab.component.ts
@@ -129,20 +129,13 @@ export class SubscriptionStatsTab implements OnInit {
   }
 
   setDisplayReportStatus(){
-    console.log("TEST")
-    console.log(this.selectedCycle)
-    console.log(this.subscription)
     let now = new Date()
     let endDate = new Date(this.selectedCycle.end_date)
     if(now.getTime() > endDate.getTime()){
       this.allowCycleDownload = true;
-      console.log(this.allowCycleDownload)
     } else {
       this.allowCycleDownload = false
-      console.log(now)
-      console.log(endDate)
     }
-    console.log(this.allowCycleDownload)
   }
 
   buildSubscriptionTimeline(s: SubscriptionModel) {


### PR DESCRIPTION
## 🗣 Description ##
Disable the report button when the cycle is currently active or in the cooldown phase. Will allow it to show once in the buffer phase.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

To disable the button when it will not show correct data. To inform the user why the button is disabled when it is in the disabled state.

## 🧪 Testing ##

Tested against multiple local subscriptions and cycles.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
